### PR TITLE
Proposal: Cluster Scheduler

### DIFF
--- a/docs/proposals/scheduler/README.md
+++ b/docs/proposals/scheduler/README.md
@@ -12,7 +12,7 @@ It is the interface between the Controller and the Agent.
 
 The Scheduler is responsible for:
 
-- Sending workload scheduling/re-scheduling
+- Scheduling and re-scheduling `orka` workloads
 - Nodes and Workload Instances status updates
     - Received from the Agents
     - Sent to the Controller

--- a/docs/proposals/scheduler/README.md
+++ b/docs/proposals/scheduler/README.md
@@ -5,31 +5,29 @@
 
 ### Service provided
 
-The Scheduler is responsible for the scheduling of nodes and workloads.
+The Scheduler is responsible for scheduling workloads across the cluster nodes.
 It is the interface between the Controller and the Agent.
 
 ### Scope
 
-The Scheduler is reponsible for:
+The Scheduler is responsible for:
 
 - Sending workload scheduling/re-scheduling
-    - Re-scheduling can happen upon Agent disconnection
 - Nodes and Workload Instances status updates
-    - received from the Agents
-    - sent to the Controller
+    - Received from the Agents
+    - Sent to the Controller
 - Handling of Agent connection
-    - the Scheduler is responsible for the handshake
-    - secure connection should be made between Agent and Scheduler
+    - The Scheduler is responsible for accepting new connections
+    - Secure connection must be made between Agent and Scheduler
 
-The Scheduler is NOT responsible for:
+### Out of Scope
 
 - Workload management (creation/update/deletion)
 - Node management (connection/disconnection)
-    - the Scheduler is only receiving status updates
-    - the Agent is responsible for its connection and disconnection to the Scheduler
+    - The Scheduler is only receiving status updates
+    - The Agent is responsible for connecting to and disconnecting from the Scheduler
 - Rescheduling workloads automatically in case of an Agent disconnection
-    - this is the Controller's responsbility
-    - the Controller needs to call the Scheduler with a reschedule order
+    - Workload lifecycle management is the Controller's responsibility
 
 
 ## High Level Architecture
@@ -135,7 +133,7 @@ sequenceDiagram
 
 ## API
 
-The Scheduler is interactable through gRPC. It exposes two APIs: the Controller side, and the Agent side.
+The Scheduler can be interacted with using gRPC. It exposes two APIs: the Controller side, and the Agent side.
 
 Each API is defined in its gRPC `.proto` file:
 

--- a/docs/proposals/scheduler/README.md
+++ b/docs/proposals/scheduler/README.md
@@ -1,0 +1,144 @@
+
+# Orka - Cluster Scheduler
+
+## Requirements
+
+### Service provided
+
+The Scheduler is responsible for the scheduling of nodes and workloads.
+It is the interface between the Controller and the Agent.
+
+### Scope
+
+The Scheduler is reponsible for:
+
+- Sending workload scheduling/re-scheduling
+    - Re-scheduling can happen upon Agent disconnection
+- Nodes and Workload Instances status updates
+    - received from the Agents
+    - sent to the Controller
+- Handling of Agent connection
+    - the Scheduler is responsible for the handshake
+    - secure connection should be made between Agent and Scheduler
+
+The Scheduler is NOT responsible for:
+
+- Workload management (creation/update/deletion)
+- Node management (connection/disconnection)
+    - the Scheduler is only receiving status updates
+    - the Agent is responsible for its connection and disconnection to the Scheduler
+- Rescheduling workloads automatically in case of an Agent disconnection
+    - this is the Controller's responsbility
+    - the Controller needs to call the Scheduler with a reschedule order
+
+
+## High Level Architecture
+
+```mermaid
+---
+title: Workload Instance Scheduling
+---
+sequenceDiagram
+    autonumber
+    participant c as Controller
+    participant s as Scheduler
+    participant a as Agent
+
+    c->>s: Instance scheduling request
+
+    activate s
+
+    s->>s: self-check of available nodes
+    s->>s: determine scheduling priority
+
+    loop for each node in priority order
+        s->>a: Instance scheduling request
+        
+        alt Agent accepted scheduling
+            a-->>s: OK
+        else
+            a-->>s: NOK
+        end
+    end
+
+    alt one Agent accepted instance scheduling
+        s-->>c: scheduling sucessful
+    else
+        s-->>c: Instance scheduling failed
+    end
+
+    deactivate s
+
+```
+
+```mermaid
+---
+title: Agent lifecycle
+---
+sequenceDiagram
+    autonumber
+    participant a as Agent
+    participant s as Scheduler
+    participant c as Controller
+
+    activate a
+    a->>a: certificate gathering
+
+    Note left of a: Connection
+
+    a->>+s: Connection request with certificate
+    
+    s->>s: Certificate verification
+
+    alt Invalid certificate
+        s-->>a: Connection denied
+    else
+        s-->>-a: Connection successful
+    end
+    deactivate a
+
+    Note left of a: Periodic updates
+
+    activate a
+    loop periodically
+        a--)+s: Node and instances update
+        s--)c: Transmission of received status
+    end
+    deactivate a
+
+    Note left of a: Graceful termination
+
+    activate a
+    activate s
+    a--)s: disconnection notification
+    s->>+c: transmission of given notification
+    c->>c: rescheduling (see "Workload Instance scheduling")
+    c-->>-s: OK
+    deactivate s
+    deactivate a
+
+    Note left of a: Loss of contact
+
+    activate a
+    activate s
+    break connection timeout
+        a--)+s: timeout
+        s->>+c: node timeout
+        c->>c: rescheduling (see "Workload Instance scheduling")
+        c-->>-s: OK
+    end
+    deactivate s
+    deactivate a
+
+```
+
+
+## API
+
+The Scheduler is interactable through gRPC. It exposes two APIs: the Controller side, and the Agent side.
+
+Each API is defined in its gRPC `.proto` file:
+
+- [`controller.proto`](./controller.proto)
+- [`agent.proto`](./agent.proto)
+

--- a/docs/proposals/scheduler/agent.proto
+++ b/docs/proposals/scheduler/agent.proto
@@ -68,6 +68,6 @@ message InstanceStatuses {
 }
 
 service StatusUpdateService {
-    rpc UpdateNodeStatus(NodeStatus) returns (Empty);
+    rpc UpdateNodeStatus(stream NodeStatus) returns (Empty);
     rpc UpdateInstanceStatuses(InstanceStatuses) returns (Empty);
 }

--- a/docs/proposals/scheduler/agent.proto
+++ b/docs/proposals/scheduler/agent.proto
@@ -57,7 +57,7 @@ message InstanceStatus {
         int32 disk = 3;
     }
 
-    string id = 1;
+    string name = 1;
     StatusCode status_code = 2;
     Resources resource_usage = 3;
     string message = 4;

--- a/docs/proposals/scheduler/agent.proto
+++ b/docs/proposals/scheduler/agent.proto
@@ -8,7 +8,7 @@ message Empty {}
 // ------------------
 
 message ConnectionRequest {
-    string uuid = 1;
+    string id = 1;
 }
 
 message ConnectionResponse {
@@ -44,30 +44,6 @@ message NodeStatus {
     CpuLoad cpu_load = 2;
 }
 
-message InstanceStatus {
-    enum StatusCode {
-        WAITING = 0;
-        RUNNING = 1;
-        TERMINATED = 2;
-    }
-
-    message Resources {
-        int32 cpu = 1;
-        int32 memory = 2;
-        int32 disk = 3;
-    }
-
-    string name = 1;
-    StatusCode status_code = 2;
-    Resources resource_usage = 3;
-    string message = 4;
-}
-
-message InstanceStatuses {
-    repeated InstanceStatus instance_statuses = 1;
-}
-
 service StatusUpdateService {
     rpc UpdateNodeStatus(stream NodeStatus) returns (Empty);
-    rpc UpdateInstanceStatuses(InstanceStatuses) returns (Empty);
 }

--- a/docs/proposals/scheduler/agent.proto
+++ b/docs/proposals/scheduler/agent.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+message Empty {}
+
 
 // ------------------
 // Lifecycle
@@ -9,8 +11,13 @@ message ConnectionRequest {
     // agent certificate here
 }
 
+enum ConnectionStatus {
+    GRANTED = 0;
+    DENIED = 1;
+}
+
 message ConnectionResponse {
-    // whether the agent was accepted or not
+    ConnectionStatus status = 1;
 }
 
 service LifecycleService {
@@ -34,6 +41,6 @@ message InstanceStatusUpdateNotification {
 }
 
 service StatusUpdateService {
-    rpc NodeStatus(NodeStatusUpdateNotification) returns ();
-    rpc InstanceStatus(InstanceStatusUpdateNotification) returns ();
+    rpc NodeStatus(NodeStatusUpdateNotification) returns (Empty);
+    rpc InstanceStatus(InstanceStatusUpdateNotification) returns (Empty);
 }

--- a/docs/proposals/scheduler/agent.proto
+++ b/docs/proposals/scheduler/agent.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+
+// ------------------
+// Lifecycle
+// ------------------
+
+message ConnectionRequest {
+    // agent certificate here
+}
+
+message ConnectionResponse {
+    // whether the agent was accepted or not
+}
+
+service LifecycleService {
+    rpc Connect(ConnectionRequest) returns (ConnectionResponse);
+    rpc Disconnect() returns ();
+}
+
+
+// ------------------
+// Status updates
+// ------------------
+
+message NodeStatusUpdateNotification {
+    // update about the node status
+    // such as amount of RAM, CPU, etc.
+}
+
+message InstanceStatusUpdateNotification {
+    // update about instances hosted on the node
+    // such as number of instances down, to reschedule, etc.
+}
+
+service StatusUpdateService {
+    rpc NodeStatus(NodeStatusUpdateNotification) returns ();
+    rpc InstanceStatus(InstanceStatusUpdateNotification) returns ();
+}

--- a/docs/proposals/scheduler/agent.proto
+++ b/docs/proposals/scheduler/agent.proto
@@ -8,21 +8,21 @@ message Empty {}
 // ------------------
 
 message ConnectionRequest {
-    // agent certificate here
-}
-
-enum ConnectionStatus {
-    GRANTED = 0;
-    DENIED = 1;
+    string uuid = 1;
 }
 
 message ConnectionResponse {
-    ConnectionStatus status = 1;
+    enum StatusCode {
+        GRANTED = 0;
+        DENIED = 1;
+    }
+
+    StatusCode status_code = 1;
 }
 
 service LifecycleService {
     rpc Connect(ConnectionRequest) returns (ConnectionResponse);
-    rpc Disconnect() returns ();
+    rpc Disconnect(Empty) returns (Empty);
 }
 
 
@@ -30,17 +30,44 @@ service LifecycleService {
 // Status updates
 // ------------------
 
-message NodeStatusUpdateNotification {
-    // update about the node status
-    // such as amount of RAM, CPU, etc.
+message NodeStatus {
+    message Memory {
+        uint64 total = 1;
+        uint64 free = 2;
+    }
+
+    message CpuLoad {
+        double load = 1;
+    }
+
+    Memory memory = 1;
+    CpuLoad cpu_load = 2;
 }
 
-message InstanceStatusUpdateNotification {
-    // update about instances hosted on the node
-    // such as number of instances down, to reschedule, etc.
+message InstanceStatus {
+    enum StatusCode {
+        WAITING = 0;
+        RUNNING = 1;
+        TERMINATED = 2;
+    }
+
+    message Resources {
+        int32 cpu = 1;
+        int32 memory = 2;
+        int32 disk = 3;
+    }
+
+    string id = 1;
+    StatusCode status_code = 2;
+    Resources resource_usage = 3;
+    string message = 4;
+}
+
+message InstanceStatuses {
+    repeated InstanceStatus instance_statuses = 1;
 }
 
 service StatusUpdateService {
-    rpc NodeStatus(NodeStatusUpdateNotification) returns (Empty);
-    rpc InstanceStatus(InstanceStatusUpdateNotification) returns (Empty);
+    rpc UpdateNodeStatus(NodeStatus) returns (Empty);
+    rpc UpdateInstanceStatuses(InstanceStatuses) returns (Empty);
 }

--- a/docs/proposals/scheduler/controller.proto
+++ b/docs/proposals/scheduler/controller.proto
@@ -16,12 +16,11 @@ message Workload {
         optional int32 disk = 3;
     }
 
-    string id = 1;
-    string name = 2;
-    Type type = 3;
-    string image = 4;
-    repeated string environment = 5;
-    optional Resources resource_limits = 6;
+    string name = 1;
+    Type type = 2;
+    string image = 3;
+    repeated string environment = 4;
+    optional Resources resource_limits = 5;
 }
 
 message SchedulingRequest {

--- a/docs/proposals/scheduler/controller.proto
+++ b/docs/proposals/scheduler/controller.proto
@@ -11,9 +11,9 @@ message Workload {
     }
 
     message Resources {
-        int32 cpu = 1;
-        int32 memory = 2;
-        int32 disk = 3;
+        optional int32 cpu = 1;
+        optional int32 memory = 2;
+        optional int32 disk = 3;
     }
 
     string id = 1;
@@ -21,7 +21,7 @@ message Workload {
     Type type = 3;
     string image = 4;
     repeated string environment = 5;
-    Resources resource_limits = 6;
+    optional Resources resource_limits = 6;
 }
 
 message SchedulingRequest {

--- a/docs/proposals/scheduler/controller.proto
+++ b/docs/proposals/scheduler/controller.proto
@@ -9,8 +9,18 @@ message SchedulingRequest {
     // definition of the workload
 }
 
+enum SchedulingStatus {
+    SCHEDULED = 0;
+    // the request was malformed or safety checks failed
+    BAD_REQUEST = 1;
+    // no underlying agent could be contacted to schedule
+    NO_CONTACTABLE_AGENT = 2;
+    // all contacted agents refused the workload
+    AGENTS_REFUSED_OPERATION = 3;
+}
+
 message SchedulingResponse {
-    // whether the scheduling was successful
+    SchedulingStatus status = 1;
 }
 
 service SchedulingService {

--- a/docs/proposals/scheduler/controller.proto
+++ b/docs/proposals/scheduler/controller.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+
+// ------------------
+// Scheduling
+// ------------------
+
+message SchedulingRequest {
+    // definition of the workload
+}
+
+message SchedulingResponse {
+    // whether the scheduling was successful
+}
+
+service SchedulingService {
+    rpc Schedule(SchedulingRequest) returns (SchedulingResponse);
+}

--- a/docs/proposals/scheduler/controller.proto
+++ b/docs/proposals/scheduler/controller.proto
@@ -44,6 +44,25 @@ message SchedulingResponse {
     optional RejectionReason rejection_reason = 2;
 }
 
+message WorkloadStatus {
+    enum StatusCode {
+        WAITING = 0;
+        RUNNING = 1;
+        TERMINATED = 2;
+    }
+
+    message Resources {
+        int32 cpu = 1;
+        int32 memory = 2;
+        int32 disk = 3;
+    }
+
+    string name = 1;
+    StatusCode status_code = 2;
+    Resources resource_usage = 3;
+    string message = 4;
+}
+
 service SchedulingService {
-    rpc Schedule(SchedulingRequest) returns (SchedulingResponse);
+    rpc Schedule(SchedulingRequest) returns (stream WorkloadStatus);
 }

--- a/docs/proposals/scheduler/controller.proto
+++ b/docs/proposals/scheduler/controller.proto
@@ -5,22 +5,44 @@ syntax = "proto3";
 // Scheduling
 // ------------------
 
-message SchedulingRequest {
-    // definition of the workload
+message Workload {
+    enum Type {
+        CONTAINER = 0;
+    }
+
+    message Resources {
+        int32 cpu = 1;
+        int32 memory = 2;
+        int32 disk = 3;
+    }
+
+    string id = 1;
+    string name = 2;
+    Type type = 3;
+    string image = 4;
+    repeated string environment = 5;
+    Resources resource_limits = 6;
 }
 
-enum SchedulingStatus {
-    SCHEDULED = 0;
-    // the request was malformed or safety checks failed
-    BAD_REQUEST = 1;
-    // no underlying agent could be contacted to schedule
-    NO_CONTACTABLE_AGENT = 2;
-    // all contacted agents refused the workload
-    AGENTS_REFUSED_OPERATION = 3;
+message SchedulingRequest {
+    Workload workload = 1;
 }
 
 message SchedulingResponse {
-    SchedulingStatus status = 1;
+    enum StatusCode {
+        SCHEDULED = 0;
+        SCHEDULING = 1;
+        REJECTED = 2;
+    }
+
+    enum RejectionReason {
+        BAD_REQUEST = 0;
+        NO_CONTACTABLE_AGENT = 1;
+        AGENTS_REFUSED_OPERATION = 2;
+    }
+
+    StatusCode status_code = 1;
+    optional RejectionReason rejection_reason = 2;
 }
 
 service SchedulingService {


### PR DESCRIPTION
This proposal features the description of service, domain scope and requirements for the Cluster Scheduler.

It also features stubs for the `.proto` files required to interact with the Scheduler. gRPC messages specifications have not yet been discussed with other teams, and are for now left empty.

The term "workload" and its associated components still need to be defined in order for the `SchedulingRequest` message to be correctly formed.