### PR TITLE
Add the skeleton of Orka's scheduler

### DIFF
--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "orka-scheduler"
+description = "Scheduler service for the Orka container orchestration system"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = { version = "1.0.72", features = ["backtrace"] }
+clap = { version = "4.3.21", features = ["derive", "env"] }
+clap-verbosity-flag = "2.0.1"
+env_logger = "0.10.0"
+log = "0.4.19"
+orka-proto = { path = "../proto" }
+prost = "0.11.9"
+prost-types = "0.11.9"
+rcgen = "0.11.1"
+time = "0.3.25"
+tokio = { version = "1.30.0", features = ["macros", "rt-multi-thread"] }
+tokio-stream = "0.1.14"
+tonic = { version = "0.9.2", features = ["transport", "codegen", "tls", "prost"] }

--- a/scheduler/src/args.rs
+++ b/scheduler/src/args.rs
@@ -1,0 +1,61 @@
+//! Command-line arguments.
+
+use std::{fs, io::ErrorKind};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use clap_verbosity_flag::{InfoLevel, Verbosity};
+use log::debug;
+
+/// Scheduler service for the Orka container orchestration system.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct CliArguments {
+    /// Directory used to store the configuration.
+    #[arg(long, default_value = "/var/lib/orka/scheduler/", env)]
+    pub data_dir: String,
+
+    /// Disable TLS for the gRPC server.
+    #[arg(long, default_value_t = false, env)]
+    pub no_tls: bool,
+
+    /// Disable the automatic generation of the keypair and certificate for TLS.
+    #[arg(long, default_value_t = false, env)]
+    pub no_tls_secret_generation: bool,
+
+    /// The address to bind the gRPC server to.
+    #[arg(long, default_value = "[::]", env)]
+    pub grpc_bind_address: String,
+
+    /// The port to bind the gRPC server to.
+    #[arg(long, default_value_t = 50051, env)]
+    pub grpc_bind_port: u16,
+
+    /// Verbosity level.
+    #[command(flatten)]
+    pub verbose: Verbosity<InfoLevel>,
+}
+
+impl CliArguments {
+    /// Prepare the application directories by creating them.
+    ///
+    /// # Errors
+    ///
+    /// * The directories could not be created.
+    pub fn prepare_directories(&self) -> Result<()> {
+        // Create the required directories
+        match fs::create_dir_all(&self.data_dir) {
+            Err(e) if e.kind() != ErrorKind::AlreadyExists => Err(e),
+            _ => Ok(()),
+        }
+        .with_context(|| {
+            format!(
+                "Failed to create the main data directory: {}",
+                self.data_dir
+            )
+        })?;
+
+        debug!("Created application data directory: {}", self.data_dir);
+        Ok(())
+    }
+}

--- a/scheduler/src/grpc/agent_lifecycle_service.rs
+++ b/scheduler/src/grpc/agent_lifecycle_service.rs
@@ -1,0 +1,34 @@
+//! Lifecycle gRPC service for the Orka node agents.
+
+use orka_proto::scheduler_agent::{
+    lifecycle_service_server::LifecycleService, ConnectionRequest, ConnectionResponse, Empty,
+};
+use tonic::{Request, Response, Result};
+
+/// Implementation of the `LifecycleService` gRPC service.
+pub struct AgentLifecycleSvc {}
+
+impl AgentLifecycleSvc {
+    /// Create a new `LifecycleService` gRPC service manager.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[tonic::async_trait]
+impl LifecycleService for AgentLifecycleSvc {
+    /// Called by node agents when they request to join the cluster.
+    async fn join_cluster(
+        &self,
+        _: Request<ConnectionRequest>,
+    ) -> Result<Response<ConnectionResponse>> {
+        todo!();
+        // Ok(Response::new(ConnectionResponse { status_code: 200 }))
+    }
+
+    /// Called by node agents when they request to gracefully leave the cluster.
+    async fn leave_cluster(&self, _: Request<Empty>) -> Result<Response<Empty>> {
+        todo!();
+        // Ok(Response::new(Empty {}))
+    }
+}

--- a/scheduler/src/grpc/agent_status_update_service.rs
+++ b/scheduler/src/grpc/agent_status_update_service.rs
@@ -1,0 +1,28 @@
+//! Status update gRPC service for the Orka node agents.
+
+use orka_proto::scheduler_agent::{
+    status_update_service_server::StatusUpdateService, Empty, NodeStatus,
+};
+use tonic::{Request, Response, Result, Streaming};
+
+/// Implementation of the `StatusUpdateService` gRPC service.
+pub struct AgentStatusUpdateSvc {}
+
+impl AgentStatusUpdateSvc {
+    /// Create a new `StatusUpdateService` gRPC service manager.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[tonic::async_trait]
+impl StatusUpdateService for AgentStatusUpdateSvc {
+    /// Called by node agents to start streaming status information about the node.
+    async fn update_node_status(
+        &self,
+        _: Request<Streaming<NodeStatus>>,
+    ) -> Result<Response<Empty>> {
+        todo!();
+        // Ok(Response::new(Empty {}))
+    }
+}

--- a/scheduler/src/grpc/controller_scheduling_service.rs
+++ b/scheduler/src/grpc/controller_scheduling_service.rs
@@ -1,0 +1,56 @@
+//! Scheduling gRPC service for the Orka controller.
+
+use std::pin::Pin;
+
+use orka_proto::scheduler_controller::{
+    scheduling_service_server::SchedulingService, SchedulingRequest, WorkloadStatus,
+};
+use tokio_stream::Stream;
+use tonic::{Request, Response, Result};
+
+/// Implementation of the `SchedulingService` gRPC service.
+pub struct ControllerSchedulingSvc {}
+
+impl ControllerSchedulingSvc {
+    /// Create a new `SchedulingService` gRPC service manager.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[tonic::async_trait]
+impl SchedulingService for ControllerSchedulingSvc {
+    type ScheduleStream = Pin<Box<dyn Stream<Item = Result<WorkloadStatus>> + Send>>;
+
+    /// Called by the controller when it requests to schedule a workload on a node. The scheduler
+    /// responds by streaming status information about the workload.
+    async fn schedule(
+        &self,
+        _: Request<SchedulingRequest>,
+    ) -> Result<Response<Self::ScheduleStream>> {
+        todo!();
+        // Example: https://github.com/hyperium/tonic/blob/master/examples/src/streaming
+        //let (tx, rx) = mpsc::channel(128);
+        //tokio::spawn(async move {
+        //    match tx.send(Ok(WorkloadStatus {
+        //        name: "my_workload".to_string(),
+        //        status_code: StatusCode::Running.into(),
+        //        resource_usage: Some(Resources {
+        //            cpu: 1,
+        //            memory: 1,
+        //            disk: 1,
+        //        }),
+        //        message: "Everything is fine".to_string(),
+        //    }))
+        //    .await {
+        //        Ok(_) => (),
+        //        Err(_) => (),
+        //    };
+        //});
+
+        //let output_stream = ReceiverStream::new(rx);
+        //Ok(Response::new(
+        //    Box::pin(output_stream) as Self::ScheduleStream
+        //))
+    }
+}

--- a/scheduler/src/grpc/mod.rs
+++ b/scheduler/src/grpc/mod.rs
@@ -1,0 +1,6 @@
+//! Services and server for gRPC.
+
+pub mod agent_lifecycle_service;
+pub mod agent_status_update_service;
+pub mod controller_scheduling_service;
+pub mod server;

--- a/scheduler/src/grpc/server.rs
+++ b/scheduler/src/grpc/server.rs
@@ -1,0 +1,101 @@
+//! The gRPC server for interacting with the Orka scheduler.
+
+use std::net::SocketAddr;
+
+use anyhow::{Context, Result};
+use log::{debug, info};
+use orka_proto::{
+    scheduler_agent::{
+        lifecycle_service_server::LifecycleServiceServer,
+        status_update_service_server::StatusUpdateServiceServer,
+    },
+    scheduler_controller::scheduling_service_server::SchedulingServiceServer,
+};
+use tonic::transport::{Identity, Server, ServerTlsConfig};
+
+use crate::tls::manager::TlsManager;
+
+use super::{
+    agent_lifecycle_service::AgentLifecycleSvc, agent_status_update_service::AgentStatusUpdateSvc,
+    controller_scheduling_service::ControllerSchedulingSvc,
+};
+
+/// The gRPC server manager for the scheduler.
+pub struct GrpcServer {
+    /// The address to bind the gRPC server to.
+    bind_socket_address: SocketAddr,
+
+    /// The TLS manager, if it is enabled.
+    tls_manager: Option<TlsManager>,
+}
+
+impl GrpcServer {
+    /// Create a gRPC server manager.
+    ///
+    /// # Arguments
+    ///
+    /// * `bind_address` - The address to bind the gRPC server to.
+    /// * `bind_port` - The port to bind the gRPC server to.
+    /// * `tls_manager` - The TLS manager, if TLS is enabled.
+    pub fn new(
+        bind_address: String,
+        bind_port: u16,
+        tls_manager: Option<TlsManager>,
+    ) -> Result<Self> {
+        let bind_socket_address = format!("{}:{}", bind_address, bind_port)
+            .parse()
+            .with_context(|| {
+                format!(
+                    "Unable to parse the gRPC bind address: bind_address={:?}, bind_port={:?}",
+                    bind_address, bind_port
+                )
+            })?;
+
+        Ok(Self {
+            bind_socket_address,
+            tls_manager,
+        })
+    }
+
+    /// Start the gRPC server.
+    pub async fn start_server(&self) -> Result<()> {
+        // Configure the server
+        info!("Starting gRPC server on {}", self.bind_socket_address);
+        let mut server_builder = Server::builder();
+
+        // If the TLS manager is present, configure the gRPC server with TLS
+        if let Some(tls_manager) = &self.tls_manager {
+            debug!("Configuring the gRPC server for TLS");
+
+            let cert_data = tls_manager
+                .cert_data()
+                .with_context(|| "The certificate data is missing")?;
+
+            let key_data = tls_manager
+                .key_data()
+                .with_context(|| "The private key data is missing")?;
+
+            let tls_config =
+                ServerTlsConfig::new().identity(Identity::from_pem(cert_data, key_data));
+
+            server_builder = server_builder
+                .tls_config(tls_config)
+                .with_context(|| "Unable to configure TLS with the gRPC server")?;
+        }
+
+        // Configure the router
+        let router = server_builder
+            .add_service(LifecycleServiceServer::new(AgentLifecycleSvc::new()))
+            .add_service(StatusUpdateServiceServer::new(AgentStatusUpdateSvc::new()))
+            .add_service(SchedulingServiceServer::new(ControllerSchedulingSvc::new()));
+
+        debug!("The gRPC server was configured successfully");
+
+        router
+            .serve(self.bind_socket_address)
+            .await
+            .with_context(|| "An error occurred while serving gRPC requests")?;
+
+        Ok(())
+    }
+}

--- a/scheduler/src/main.rs
+++ b/scheduler/src/main.rs
@@ -1,0 +1,63 @@
+mod args;
+mod grpc;
+mod tls;
+
+use anyhow::Context;
+use clap::Parser;
+use log::{info, trace, warn};
+use std::error;
+use std::path::Path;
+
+use crate::args::CliArguments;
+use crate::grpc::server::GrpcServer;
+use crate::tls::config::TlsConfig;
+use crate::tls::manager::TlsManager;
+
+/// The application entry point.
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn error::Error>> {
+    // Parse the configuration and configure logger verbosity
+    let args = CliArguments::parse();
+
+    env_logger::builder()
+        .filter_level(args.verbose.log_level_filter())
+        .init();
+
+    info!(
+        "Starting {} version {}",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION")
+    );
+
+    trace!("Loaded configuration: {:#?}", args);
+
+    // Prepare the application
+    args.prepare_directories()?;
+
+    let tls_manager = if !args.no_tls {
+        let tls_base_dir = &Path::new(&args.data_dir).join("tls/");
+        let tls_config = TlsConfig::new(tls_base_dir, !args.no_tls_secret_generation);
+
+        trace!("Loaded TLS configuration: {:#?}", tls_config);
+
+        tls_config.prepare_directory()?;
+
+        let mut tls_manager = TlsManager::new(tls_config);
+        tls_manager
+            .populate_secrets()
+            .with_context(|| "Unable to provide the certificate and private key for TLS")?;
+
+        Some(tls_manager)
+    } else {
+        warn!("The server will run in an unsecure mode because TLS was disabled. Are you certain whatever you're doing is worth it?");
+        None
+    };
+
+    // Start the gRPC server
+    let grpc_server = GrpcServer::new(args.grpc_bind_address, args.grpc_bind_port, tls_manager)
+        .with_context(|| "Unable to create the gRPC server manager")?;
+
+    grpc_server.start_server().await?;
+
+    Ok(())
+}

--- a/scheduler/src/tls/config.rs
+++ b/scheduler/src/tls/config.rs
@@ -1,0 +1,119 @@
+//! Configuration for TLS management.
+
+use std::{
+    fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use log::debug;
+
+/// Configuration for TLS management.
+#[derive(Debug)]
+pub struct TlsConfig {
+    /// Paths for TLS files.
+    paths: TlsPaths,
+
+    /// Whether keypair and certificate can be generated for TLS.
+    can_generate_secrets: bool,
+}
+
+/// Directory and file paths for storing TLS management data.
+#[derive(Debug)]
+pub struct TlsPaths {
+    /// Directory that contains the data for TLS.
+    base_dir: PathBuf,
+
+    /// File that contains the certificate.
+    cert_file: PathBuf,
+
+    /// File that contains the private key.
+    private_key_file: PathBuf,
+}
+
+impl TlsConfig {
+    /// Create configuration for TLS management.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_dir` - The base directory for storing TLS data.
+    /// * `can_generate_secrets` - Whether to automatically generate keypair and certificate for TLS if
+    ///                            not present in the data directory.
+    pub fn new(base_dir: &Path, can_generate_secrets: bool) -> Self {
+        Self {
+            paths: TlsPaths::new(base_dir),
+            can_generate_secrets,
+        }
+    }
+
+    /// Prepare the data directory for TLS.
+    ///
+    /// # Errors
+    ///
+    /// * The directory could not be created.
+    pub fn prepare_directory(&self) -> Result<()> {
+        self.paths.prepare_directory()?;
+
+        Ok(())
+    }
+
+    /// Get the paths for TLS files and directories.
+    pub fn paths(&self) -> &TlsPaths {
+        &self.paths
+    }
+
+    /// Get whether TLS secret generation is allowed.
+    pub fn can_generate_secrets(&self) -> bool {
+        self.can_generate_secrets
+    }
+}
+
+impl TlsPaths {
+    /// Create path configuration for TLS management.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_dir` - The base directory for storing TLS data.
+    pub fn new(base_dir: &Path) -> Self {
+        let base_dir = base_dir.to_path_buf();
+
+        Self {
+            cert_file: base_dir.join("scheduler.pem"),
+            private_key_file: base_dir.join("scheduler.key"),
+            base_dir,
+        }
+    }
+
+    /// Prepare the data directory for TLS.
+    ///
+    /// # Errors
+    ///
+    /// * The directory could not be created.
+    pub fn prepare_directory(&self) -> Result<()> {
+        // Create the base directory
+        match fs::create_dir_all(&self.base_dir) {
+            Err(e) if e.kind() != ErrorKind::AlreadyExists => Err(e),
+            _ => Ok(()),
+        }
+        .with_context(|| {
+            format!(
+                "Unable to create the base TLS directory: {}",
+                self.base_dir.display()
+            )
+        })?;
+
+        debug!("Created TLS base directory: {}", self.base_dir.display());
+        Ok(())
+    }
+
+    /// Get the path to the X509 certificate file.
+    pub fn cert_file(&self) -> &PathBuf {
+        &self.cert_file
+    }
+
+    /// Get the path to the private key file.
+    pub fn private_key_file(&self) -> &PathBuf {
+        &self.private_key_file
+    }
+}

--- a/scheduler/src/tls/manager.rs
+++ b/scheduler/src/tls/manager.rs
@@ -1,0 +1,244 @@
+//! TLS management functions.
+
+use std::{fs::File, io::Write};
+
+use anyhow::{Context, Result};
+use log::{debug, info};
+use rcgen::{Certificate, CertificateParams, DistinguishedName, DnType};
+use time::{Duration, OffsetDateTime};
+
+use super::config::TlsConfig;
+
+/// Manager for TLS secrets.
+pub struct TlsManager {
+    /// Configuration of the manager.
+    config: TlsConfig,
+
+    /// X509 certificate data.
+    cert_data: Option<String>,
+
+    /// Private key data.
+    key_data: Option<String>,
+}
+
+impl TlsManager {
+    /// Create a TLS manager.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The configuration for this manager.
+    pub fn new(config: TlsConfig) -> Self {
+        Self {
+            config,
+            cert_data: None,
+            key_data: None,
+        }
+    }
+
+    /// Populate the certificate and private key data by reading them from the files specified in
+    /// the config file, or generating them if these files do not exist and the configuration
+    /// allows it.
+    ///
+    /// # Errors
+    ///
+    /// * The TLS secrets could not be read from the disk.
+    /// * The TLS secrets could not be generated.
+    /// * The TLS secrets could not be written to the disk.
+    pub fn populate_secrets(&mut self) -> Result<()> {
+        // First, try to read the certificate and private key from the disk
+        match self.read_secrets() {
+            Ok(_) => return Ok(()),
+            Err(e) => {
+                debug!("Failed to read TLS secrets from disk");
+
+                // If TLS secret generation is disabled, there's nothing more we can do
+                if !self.config.can_generate_secrets() {
+                    return Err(e).with_context(|| "Unable to read the TLS secrets from the disk");
+                }
+            }
+        }
+
+        // If we weren't successful in reading the secrets from the disk, try generating them
+        info!("Generating certificate and private key for TLS");
+
+        self.generate_secrets()
+            .with_context(|| "Unable to generate the TLS secrets")?;
+
+        self.write_secrets()
+            .with_context(|| "Unable to write the TLS secrets to the disk")?;
+
+        Ok(())
+    }
+
+    /// Read the certificate and private key data from the disk. The file paths are specified in
+    /// the configuration.
+    ///
+    /// # Errors
+    ///
+    /// * The certificate or private key file could not be read.
+    fn read_secrets(&mut self) -> Result<()> {
+        let tls_paths = self.config.paths();
+        let cert_file_path = tls_paths.cert_file();
+        let private_key_file_path = tls_paths.private_key_file();
+
+        debug!(
+            "Reading certificate file for TLS from: {}",
+            cert_file_path.display()
+        );
+        let cert_data = std::fs::read_to_string(cert_file_path).with_context(|| {
+            format!(
+                "Unable to read certificate file for TLS: {}",
+                cert_file_path.display()
+            )
+        })?;
+
+        debug!(
+            "Reading key file for TLS from: {}",
+            private_key_file_path.display()
+        );
+        let key_data = std::fs::read_to_string(private_key_file_path).with_context(|| {
+            format!(
+                "Unable to read private key file for TLS: {}",
+                private_key_file_path.display()
+            )
+        })?;
+
+        // Everything went correctly, commit the data that was read
+        self.cert_data = Some(cert_data);
+        self.key_data = Some(key_data);
+
+        Ok(())
+    }
+
+    /// Generate a new private key and a new certificate.
+    ///
+    /// # Errors
+    ///
+    /// * The self-signed certificate could not be generated.
+    /// * The self-signed certificate could not be serialized.
+    fn generate_secrets(&mut self) -> Result<()> {
+        let subject_alt_names = ["localhost".to_string()];
+        let mut cert_params = CertificateParams::new(subject_alt_names);
+
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::OrganizationName, "Orka");
+        dn.push(DnType::OrganizationalUnitName, "Scheduler");
+        dn.push(DnType::CommonName, "Orka Scheduler TLS certificate");
+        cert_params.distinguished_name = dn;
+
+        cert_params.not_before = OffsetDateTime::now_utc() - Duration::days(1);
+        cert_params.not_after = OffsetDateTime::now_utc() + Duration::days(365 * 10);
+
+        let cert = Certificate::from_params(cert_params)
+            .with_context(|| "Unable to generate the self-signed certificate")?;
+
+        let cert_data = cert
+            .serialize_pem()
+            .with_context(|| "Unable to serialize the self-signed certificate")?;
+
+        let key_data = cert.serialize_private_key_pem();
+
+        // Everything went correctly, commit the data that was read
+        self.cert_data = Some(cert_data);
+        self.key_data = Some(key_data);
+
+        Ok(())
+    }
+
+    /// Write the certificate and private key data to the disk. The file paths are specified in the
+    /// configuration.
+    ///
+    /// # Errors
+    ///
+    /// * The certificate or private key data does not exist.
+    /// * The certificate or private key file could not be opened (for example, not enough
+    ///   permissions or the file already exists).
+    /// * The certificate or private key file could not be written to.
+    /// * The certificate or private key file could not be synced to the disk.
+    fn write_secrets(&mut self) -> Result<()> {
+        // Make sure the secrets are here
+        let cert_data = self
+            .cert_data
+            .as_ref()
+            .with_context(|| "No certificate data was provided to write to the disk")?;
+
+        let key_data = self
+            .key_data
+            .as_ref()
+            .with_context(|| "No private key data was provided to write to the disk")?;
+
+        // Intentionally prevent overwriting files, because we don't want users to loose data that
+        // they might not have saved
+        let mut file_opts = File::options();
+        file_opts.read(true).write(true).create_new(true);
+
+        let tls_paths = self.config.paths();
+        let cert_file_path = tls_paths.cert_file();
+        let private_key_file_path = tls_paths.private_key_file();
+
+        debug!(
+            "Writing certificate file for TLS to: {}",
+            cert_file_path.display()
+        );
+        let mut cert_file = file_opts.open(cert_file_path).with_context(|| {
+            format!(
+                "Unable to open certificate file for TLS: {}",
+                cert_file_path.display()
+            )
+        })?;
+
+        cert_file.write_all(cert_data.as_bytes()).with_context(|| {
+            format!(
+                "Unable to write certificate file for TLS: {}",
+                cert_file_path.display()
+            )
+        })?;
+
+        debug!(
+            "Writing key file for TLS to: {}",
+            private_key_file_path.display()
+        );
+        let mut private_key_file = file_opts.open(private_key_file_path).with_context(|| {
+            format!(
+                "Unable to open private key file for TLS: {}",
+                private_key_file_path.display()
+            )
+        })?;
+
+        private_key_file
+            .write_all(key_data.as_bytes())
+            .with_context(|| {
+                format!(
+                    "Unable to write private key file for TLS: {}",
+                    private_key_file_path.display()
+                )
+            })?;
+
+        // Make sure the data has reached the disk
+        cert_file.sync_data().with_context(|| {
+            format!(
+                "Unable to sync certificate file to disk for TLS: {}",
+                cert_file_path.display()
+            )
+        })?;
+
+        private_key_file.sync_data().with_context(|| {
+            format!(
+                "Unable to sync private key file to disk for TLS: {}",
+                private_key_file_path.display()
+            )
+        })?;
+
+        Ok(())
+    }
+
+    /// Get the raw data of the X509 certificate.
+    pub fn cert_data(&self) -> Option<&String> {
+        self.cert_data.as_ref()
+    }
+
+    /// Get the raw data of the private key.
+    pub fn key_data(&self) -> Option<&String> {
+        self.key_data.as_ref()
+    }
+}

--- a/scheduler/src/tls/mod.rs
+++ b/scheduler/src/tls/mod.rs
@@ -1,0 +1,4 @@
+//! TLS management.
+
+pub mod config;
+pub mod manager;


### PR DESCRIPTION
This adds a new binary crate, `orka-scheduler`, which is the application that takes the role of the Scheduler in Orka's architecture.

# What's implemented?

## Start up
When the scheduler starts up, it will first parse the command line arguments (described thereafter) and set the verbosity level of the logger.

Afterwards, all the necessary directories are created on the filesystem.

## TLS secrets management
Then, if TLS has not been disabled via the configuration, it is prepared for being used with gRPC:
- First, the private key and certificate are read from `$DATA_DIR/tls/scheduler.{key,pem}`
- If the files could not be read (files not present or permission denied), and TLS secrets generation has not been disabled via the configuration, then a private key and a self-signed certificate are generated
- Both files are then written to the disk for persistence

This step can fail if the private key or certificate could not:
- be read, and TLS secrets generation is disabled
- be generated
- be written to the disk (only after being generated)

The self-signed certificate is generated using the following parameters:
- `CN = Orka Scheduler TLS certificate; O = Orka; OU = Scheduler`
- Not before: server date minus one (1) day
- Not after: server date plus ten (10) years

## gRPC server

Finally, the gRPC server manager is created using the bind address and port retrieved from the configuration, and the TLS manager previously configured if it was not disabled.

The gRPC server itself will immediately be configured with:
- The TLS private key and certificate, if enabled
- Servers for the `scheduler.agent.LifecycleService`, `scheduler.agent.StatusUpdateService` and `scheduler.controller.SchedulingService` services
- The socket address to bind the server to

The gRPC server is then started, serving requests until the process is stopped.

For now, the methods in the gRPC services are only stubs that will be implemented later.

# Scheduler configuration
The scheduler can be configured through command line arguments (or environment variables, which have less priority):
- `--data-dir`: directory where the scheduler will store its data (default: `/var/lib/orka/scheduler/` - the parent directory has been discussed and is expected to be used by all Orka services)
- `--no-tls`: disable TLS for the gRPC server
- `--no-tls-secret-generation`: disable the generation of the certificate and private key for TLS if none has been found in the data directory
- `--grpc-bind-address`: the address to bind the gRPC server to
- `--grpc-bind-port`: the port to bind the gRPC server to
- `-v`, `--verbose`, `-q`, `--quiet`: increase/decrease the verbosity level of the logger