### PR TITLE
Improve logging on scheduler

### DIFF
--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 anyhow = { version = "1.0.72", features = ["backtrace"] }
 clap = { version = "4.3.21", features = ["derive", "env"] }
 clap-verbosity-flag = "2.0.1"
-env_logger = "0.10.0"
 log = "0.4.19"
 orka-proto = { path = "../proto" }
 prost = "0.11.9"
@@ -19,3 +18,7 @@ time = "0.3.25"
 tokio = { version = "1.30.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.14"
 tonic = { version = "0.9.2", features = ["transport", "codegen", "tls", "prost"] }
+tower-http = { version = "0.4.3", features = ["trace"] }
+tracing = "0.1.37"
+tracing-log = "0.1.3"
+tracing-subscriber = "0.3.17"

--- a/scheduler/src/args.rs
+++ b/scheduler/src/args.rs
@@ -5,7 +5,7 @@ use std::{fs, io::ErrorKind};
 use anyhow::{Context, Result};
 use clap::Parser;
 use clap_verbosity_flag::{InfoLevel, Verbosity};
-use log::debug;
+use tracing::{event, Level};
 
 /// Scheduler service for the Orka container orchestration system.
 #[derive(Parser, Debug)]
@@ -55,7 +55,11 @@ impl CliArguments {
             )
         })?;
 
-        debug!("Created application data directory: {}", self.data_dir);
+        event!(
+            Level::DEBUG,
+            path = self.data_dir,
+            "Created application data directory"
+        );
         Ok(())
     }
 }

--- a/scheduler/src/tls/config.rs
+++ b/scheduler/src/tls/config.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use log::debug;
+use tracing::{event, Level};
 
 /// Configuration for TLS management.
 #[derive(Debug)]
@@ -103,7 +103,7 @@ impl TlsPaths {
             )
         })?;
 
-        debug!("Created TLS base directory: {}", self.base_dir.display());
+        event!(Level::DEBUG, path = %self.base_dir.display(), "Created TLS base directory");
         Ok(())
     }
 

--- a/scheduler/src/tls/manager.rs
+++ b/scheduler/src/tls/manager.rs
@@ -3,9 +3,9 @@
 use std::{fs::File, io::Write};
 
 use anyhow::{Context, Result};
-use log::{debug, info};
 use rcgen::{Certificate, CertificateParams, DistinguishedName, DnType};
 use time::{Duration, OffsetDateTime};
+use tracing::{event, Level};
 
 use super::config::TlsConfig;
 
@@ -49,7 +49,7 @@ impl TlsManager {
         match self.read_secrets() {
             Ok(_) => return Ok(()),
             Err(e) => {
-                debug!("Failed to read TLS secrets from disk");
+                event!(Level::DEBUG, "Failed to read TLS secrets from disk");
 
                 // If TLS secret generation is disabled, there's nothing more we can do
                 if !self.config.can_generate_secrets() {
@@ -59,7 +59,10 @@ impl TlsManager {
         }
 
         // If we weren't successful in reading the secrets from the disk, try generating them
-        info!("Generating certificate and private key for TLS");
+        event!(
+            Level::INFO,
+            "Generating certificate and private key for TLS"
+        );
 
         self.generate_secrets()
             .with_context(|| "Unable to generate the TLS secrets")?;
@@ -81,9 +84,10 @@ impl TlsManager {
         let cert_file_path = tls_paths.cert_file();
         let private_key_file_path = tls_paths.private_key_file();
 
-        debug!(
-            "Reading certificate file for TLS from: {}",
-            cert_file_path.display()
+        event!(
+            Level::DEBUG,
+            path = %cert_file_path.display(),
+            "Reading certificate file for TLS"
         );
         let cert_data = std::fs::read_to_string(cert_file_path).with_context(|| {
             format!(
@@ -92,9 +96,10 @@ impl TlsManager {
             )
         })?;
 
-        debug!(
-            "Reading key file for TLS from: {}",
-            private_key_file_path.display()
+        event!(
+            Level::DEBUG,
+            path = %private_key_file_path.display(),
+            "Reading key file for TLS"
         );
         let key_data = std::fs::read_to_string(private_key_file_path).with_context(|| {
             format!(
@@ -176,9 +181,10 @@ impl TlsManager {
         let cert_file_path = tls_paths.cert_file();
         let private_key_file_path = tls_paths.private_key_file();
 
-        debug!(
-            "Writing certificate file for TLS to: {}",
-            cert_file_path.display()
+        event!(
+            Level::DEBUG,
+            path = %cert_file_path.display(),
+            "Writing certificate file for TLS"
         );
         let mut cert_file = file_opts.open(cert_file_path).with_context(|| {
             format!(
@@ -194,9 +200,10 @@ impl TlsManager {
             )
         })?;
 
-        debug!(
-            "Writing key file for TLS to: {}",
-            private_key_file_path.display()
+        event!(
+            Level::DEBUG,
+            path = %private_key_file_path.display(),
+            "Writing key file for TLS"
         );
         let mut private_key_file = file_opts.open(private_key_file_path).with_context(|| {
             format!(


### PR DESCRIPTION
This follows internal discussion and ideas on #13.

Logging on the scheduler is now managed by the `tracing` library, instead of `env_logger`, which allows for richer and better traceability by:

- adding the concept of events, which are akin to log lines
- adding the concept of spans, which are context-bound time frames in which multiple events happen
- normalize how variables are emitted in events

In that regard, the trace layer from `tower-http` has been added to the gRPC server as a middleware, which will:

- emit an event on each request and response (in the `DEBUG` log level), with info such as the status code or latency
- automatically set up a span for our own events