### PR TITLE
Add Agent lifecycle support for Orka's Scheduler

### DIFF
--- a/docs/proposals/scheduler/agent.proto
+++ b/docs/proposals/scheduler/agent.proto
@@ -13,18 +13,13 @@ message ConnectionRequest {
     string id = 1;
 }
 
-message ConnectionResponse {
-    enum StatusCode {
-        GRANTED = 0;
-        DENIED = 1;
-    }
-
-    StatusCode status_code = 1;
+message DisconnectionNotice {
+    string id = 1;
 }
 
 service LifecycleService {
-    rpc JoinCluster(ConnectionRequest) returns (ConnectionResponse);
-    rpc LeaveCluster(Empty) returns (Empty);
+    rpc JoinCluster(ConnectionRequest) returns (Empty);
+    rpc LeaveCluster(DisconnectionNotice) returns (Empty);
 }
 
 
@@ -42,8 +37,9 @@ message NodeStatus {
         double load = 1;
     }
 
-    Memory memory = 1;
-    CpuLoad cpu_load = 2;
+    string id = 1;
+    Memory memory = 2;
+    CpuLoad cpu_load = 3;
 }
 
 service StatusUpdateService {

--- a/proto/src/scheduler/agent.proto
+++ b/proto/src/scheduler/agent.proto
@@ -13,18 +13,13 @@ message ConnectionRequest {
     string id = 1;
 }
 
-message ConnectionResponse {
-    enum StatusCode {
-        GRANTED = 0;
-        DENIED = 1;
-    }
-
-    StatusCode status_code = 1;
+message DisconnectionNotice {
+    string id = 1;
 }
 
 service LifecycleService {
-    rpc JoinCluster(ConnectionRequest) returns (ConnectionResponse);
-    rpc LeaveCluster(Empty) returns (Empty);
+    rpc JoinCluster(ConnectionRequest) returns (Empty);
+    rpc LeaveCluster(DisconnectionNotice) returns (Empty);
 }
 
 
@@ -42,8 +37,9 @@ message NodeStatus {
         double load = 1;
     }
 
-    Memory memory = 1;
-    CpuLoad cpu_load = 2;
+    string id = 1;
+    Memory memory = 2;
+    CpuLoad cpu_load = 3;
 }
 
 service StatusUpdateService {

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = { version = "1.0.72", features = ["backtrace"] }
+chrono = "0.4.26"
 clap = { version = "4.3.21", features = ["derive", "env"] }
 clap-verbosity-flag = "2.0.1"
 log = "0.4.19"
@@ -14,6 +15,7 @@ orka-proto = { path = "../proto" }
 prost = "0.11.9"
 prost-types = "0.11.9"
 rcgen = "0.11.1"
+thiserror = "1.0.47"
 time = "0.3.25"
 tokio = { version = "1.30.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.14"

--- a/scheduler/src/grpc/agent_lifecycle_service.rs
+++ b/scheduler/src/grpc/agent_lifecycle_service.rs
@@ -1,17 +1,29 @@
 //! Lifecycle gRPC service for the Orka node agents.
 
+use crate::managers::node_agent::manager::NodeAgentManager;
 use orka_proto::scheduler_agent::{
-    lifecycle_service_server::LifecycleService, ConnectionRequest, ConnectionResponse, Empty,
+    lifecycle_service_server::LifecycleService, ConnectionRequest, DisconnectionNotice, Empty,
 };
-use tonic::{Request, Response, Result};
+use std::sync::{Arc, Mutex};
+use tonic::{Request, Response, Result, Status};
+use tracing::{event, Level};
 
 /// Implementation of the `LifecycleService` gRPC service.
-pub struct AgentLifecycleSvc {}
+pub struct AgentLifecycleSvc {
+    /// The shared instance of the node agent manager.
+    node_agent_manager: Arc<Mutex<NodeAgentManager>>,
+}
 
 impl AgentLifecycleSvc {
     /// Create a new `LifecycleService` gRPC service manager.
-    pub fn new() -> Self {
-        Self {}
+    ///
+    /// # Arguments
+    ///
+    /// * `manager` - The shared instance of the node agent manager.
+    pub fn new(manager: Arc<Mutex<NodeAgentManager>>) -> Self {
+        Self {
+            node_agent_manager: manager,
+        }
     }
 }
 
@@ -20,15 +32,59 @@ impl LifecycleService for AgentLifecycleSvc {
     /// Called by node agents when they request to join the cluster.
     async fn join_cluster(
         &self,
-        _: Request<ConnectionRequest>,
-    ) -> Result<Response<ConnectionResponse>> {
-        todo!();
-        // Ok(Response::new(ConnectionResponse { status_code: 200 }))
+        request: Request<ConnectionRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let agent_id = request.into_inner().id;
+
+        let mut manager = self.node_agent_manager.lock().map_err(|err| {
+            event!(
+                Level::WARN,
+                agent_id,
+                error = %err,
+                "Failed to acquire node manager, refusing registration for agent"
+            );
+
+            Status::internal("Failed to register agent")
+        })?;
+
+        match manager.add_agent(&agent_id) {
+            Ok(_) => Ok(Response::new(Empty {})),
+            Err(err) => {
+                event!(
+                    Level::WARN,
+                    agent_id,
+                    error = %err,
+                    "Unable to accept new node agent into the cluster"
+                );
+
+                Err(Status::from(err))
+            }
+        }
     }
 
     /// Called by node agents when they request to gracefully leave the cluster.
-    async fn leave_cluster(&self, _: Request<Empty>) -> Result<Response<Empty>> {
-        todo!();
-        // Ok(Response::new(Empty {}))
+    async fn leave_cluster(
+        &self,
+        request: Request<DisconnectionNotice>,
+    ) -> Result<Response<Empty>> {
+        let agent_id = request.into_inner().id;
+
+        match self.node_agent_manager.lock() {
+            Ok(mut manager) => {
+                manager.remove_agent(&agent_id);
+            }
+            Err(err) => {
+                event!(
+                    Level::WARN,
+                    agent_id,
+                    error = %err,
+                    "Failed to acquire node manager, could not remove agent"
+                );
+            }
+        }
+
+        // We are receiving a notice and are expected not to respond
+        // so we always send an empty response
+        Ok(Response::new(Empty {}))
     }
 }

--- a/scheduler/src/grpc/agent_status_update_service.rs
+++ b/scheduler/src/grpc/agent_status_update_service.rs
@@ -1,17 +1,31 @@
 //! Status update gRPC service for the Orka node agents.
 
+use crate::managers::node_agent::manager::NodeAgentManager;
+use crate::managers::node_agent::metrics::{NodeCpu, NodeMemory};
 use orka_proto::scheduler_agent::{
     status_update_service_server::StatusUpdateService, Empty, NodeStatus,
 };
-use tonic::{Request, Response, Result, Streaming};
+use std::sync::{Arc, Mutex};
+use tokio_stream::StreamExt;
+use tonic::{Request, Response, Result, Status, Streaming};
+use tracing::{event, Level};
 
 /// Implementation of the `StatusUpdateService` gRPC service.
-pub struct AgentStatusUpdateSvc {}
+pub struct AgentStatusUpdateSvc {
+    /// The shared instance of the node agent manager.
+    node_agent_manager: Arc<Mutex<NodeAgentManager>>,
+}
 
 impl AgentStatusUpdateSvc {
     /// Create a new `StatusUpdateService` gRPC service manager.
-    pub fn new() -> Self {
-        Self {}
+    ///
+    /// # Arguments
+    ///
+    /// * `manager` - The shared instance of the node agent manager.
+    pub fn new(manager: Arc<Mutex<NodeAgentManager>>) -> Self {
+        Self {
+            node_agent_manager: manager,
+        }
     }
 }
 
@@ -20,9 +34,60 @@ impl StatusUpdateService for AgentStatusUpdateSvc {
     /// Called by node agents to start streaming status information about the node.
     async fn update_node_status(
         &self,
-        _: Request<Streaming<NodeStatus>>,
+        request: Request<Streaming<NodeStatus>>,
     ) -> Result<Response<Empty>> {
-        todo!();
-        // Ok(Response::new(Empty {}))
+        let mut stream = request.into_inner();
+
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(status) => match self.node_agent_manager.lock() {
+                    Ok(mut manager) => {
+                        // Prepare metrics
+                        let cpu: Option<NodeCpu> =
+                            status.cpu_load.map(|cpu| NodeCpu { load: cpu.load });
+
+                        let memory: Option<NodeMemory> = status.memory.map(|m| NodeMemory {
+                            total: m.total,
+                            free: m.free,
+                        });
+
+                        // Update the node status data
+                        let res = manager.update_node_status(&status.id, cpu, memory);
+
+                        if let Err(err) = res {
+                            event!(
+                                Level::WARN,
+                                agent_id = status.id,
+                                error = %err,
+                                "Unable to process node status update"
+                            );
+
+                            return Err(Status::from(err));
+                        }
+                    }
+                    Err(err) => {
+                        event!(
+                            Level::WARN,
+                            agent_id = status.id,
+                            error = %err,
+                            "Failed to acquire node manager, cannot process node status update for agent"
+                        );
+
+                        return Err(Status::internal("Failed to process node status"));
+                    }
+                },
+                Err(err) => {
+                    event!(
+                        Level::WARN,
+                        error = %err,
+                        "An error was received while processing a node status update stream"
+                    );
+
+                    return Err(Status::internal("An error was received from the client"));
+                }
+            }
+        }
+
+        Ok(Response::new(Empty {}))
     }
 }

--- a/scheduler/src/grpc/errors.rs
+++ b/scheduler/src/grpc/errors.rs
@@ -1,0 +1,14 @@
+//! Conversions from internal errors to gRPC errors.
+
+use tonic::Status;
+
+use crate::managers::node_agent::errors::NodeAgentError;
+
+impl From<NodeAgentError> for Status {
+    fn from(value: NodeAgentError) -> Self {
+        match value {
+            NodeAgentError::NotFound(_) => Self::not_found(value.to_string()),
+            NodeAgentError::AlreadyExists(_) => Self::already_exists(value.to_string()),
+        }
+    }
+}

--- a/scheduler/src/grpc/mod.rs
+++ b/scheduler/src/grpc/mod.rs
@@ -3,4 +3,5 @@
 pub mod agent_lifecycle_service;
 pub mod agent_status_update_service;
 pub mod controller_scheduling_service;
+pub mod errors;
 pub mod server;

--- a/scheduler/src/main.rs
+++ b/scheduler/src/main.rs
@@ -1,5 +1,6 @@
 mod args;
 mod grpc;
+mod managers;
 mod tls;
 
 use anyhow::Context;

--- a/scheduler/src/managers/mod.rs
+++ b/scheduler/src/managers/mod.rs
@@ -1,0 +1,3 @@
+//! Managers for the scheduler subsystems.
+
+pub mod node_agent;

--- a/scheduler/src/managers/node_agent/errors.rs
+++ b/scheduler/src/managers/node_agent/errors.rs
@@ -1,0 +1,15 @@
+//! Node agent errors.
+
+use thiserror::Error;
+
+/// Agent error enum to have self-explanatory and compact errors.
+#[derive(Error, Debug)]
+pub enum NodeAgentError {
+    /// The node agent could not be found.
+    #[error("Agent not found: `{0}`")]
+    NotFound(String),
+
+    /// The node agent is already registered.
+    #[error("Agent already exists: `{0}`")]
+    AlreadyExists(String),
+}

--- a/scheduler/src/managers/node_agent/manager.rs
+++ b/scheduler/src/managers/node_agent/manager.rs
@@ -1,0 +1,93 @@
+//! Node agent manager used to store agents.
+
+use crate::managers::node_agent::metrics::{NodeAgent, NodeCpu, NodeMemory};
+use anyhow::Result;
+use std::collections::hash_map;
+use std::collections::HashMap;
+use tracing::{event, Level};
+
+use super::errors::NodeAgentError;
+
+/// The node agent manager, handling all agents that contact the scheduler.
+pub struct NodeAgentManager {
+    /// The list of node agents that are currently active in the cluster.
+    agents: HashMap<String, NodeAgent>,
+}
+
+impl NodeAgentManager {
+    /// Create a new `NodeAgentManager` to manage the different node agents.
+    pub fn new() -> Self {
+        Self {
+            agents: HashMap::new(),
+        }
+    }
+
+    /// Add a new agent to the managed list to keep track of it.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the agent to add.
+    ///
+    /// # Errors
+    ///
+    /// * An agent with the same ID is already in the cluster.
+    pub fn add_agent(&mut self, id: &str) -> Result<&NodeAgent, NodeAgentError> {
+        if let hash_map::Entry::Vacant(e) = self.agents.entry(id.to_string()) {
+            // No other agent has this ID
+            event!(
+                Level::INFO,
+                agent_id = e.key(),
+                "Adding new agent to the cluster"
+            );
+
+            Ok(e.insert(NodeAgent::new()))
+        } else {
+            // Reject agent as the ID is already registered
+            Err(NodeAgentError::AlreadyExists(id.to_string()))
+        }
+    }
+
+    /// Remove an agent if it exists, returning it.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the agent to remove.
+    pub fn remove_agent(&mut self, id: &str) -> Option<NodeAgent> {
+        let removed_agent = self.agents.remove(id);
+
+        if removed_agent.is_some() {
+            event!(
+                Level::INFO,
+                agent_id = id,
+                "Removing agent from the cluster"
+            );
+        }
+
+        removed_agent
+    }
+
+    /// Update the node status for the given agent.
+    /// Metrics are [`NodeCpu`] and [`NodeMemory`].
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the agent to update.
+    /// * `cpu` - The new CPU metrics of the node, if any.
+    /// * `memory` - The new memory metrics of the node, if any.
+    pub fn update_node_status(
+        &mut self,
+        id: &str,
+        cpu: Option<NodeCpu>,
+        memory: Option<NodeMemory>,
+    ) -> Result<&mut NodeAgent, NodeAgentError> {
+        event!(Level::TRACE, agent_id = id, "Updating the status of a node");
+
+        let agent = self
+            .agents
+            .get_mut(id)
+            .ok_or(NodeAgentError::NotFound(id.to_string()))?;
+
+        agent.update_node_metrics(cpu, memory);
+        Ok(agent)
+    }
+}

--- a/scheduler/src/managers/node_agent/metrics.rs
+++ b/scheduler/src/managers/node_agent/metrics.rs
@@ -1,0 +1,62 @@
+//! Node agent and its metrics.
+
+use chrono::{DateTime, Local};
+
+/// The memory (RAM) information of the node the agent is installed on.
+#[derive(Debug, Clone)]
+pub struct NodeMemory {
+    /// Total memory on the machine, in bytes.
+    pub total: u64,
+    /// Available memory on the machine, in bytes.
+    pub free: u64,
+}
+
+/// The CPU information of the node the agent is installed on.
+#[derive(Debug, Clone)]
+pub struct NodeCpu {
+    /// CPU load of the machine, represented by the overall CPU usage average.
+    /// Lower bound is `0.0`, upper bound is `100.0`.
+    pub load: f64,
+}
+
+/// The node agent and the information it broadcasts.
+#[derive(Debug, Clone)]
+pub struct NodeAgent {
+    /// Heartbeat represents the last time the agent communicated with the scheduler.
+    /// This is used to determine whether the agent has timed out.
+    last_heartbeat: DateTime<Local>,
+    /// The last transmitted memory metrics of the agent's machine.
+    /// `None` only if the metrics were never communicated to the scheduler.
+    memory: Option<NodeMemory>,
+    /// The last transmitted CPU metrics of the agent's machine.
+    /// `None` only if the metrics were never communicated to the scheduler.
+    cpu: Option<NodeCpu>,
+}
+
+impl NodeAgent {
+    /// Create a new `NodeAgent`.
+    pub fn new() -> Self {
+        NodeAgent {
+            last_heartbeat: Local::now(),
+            memory: None,
+            cpu: None,
+        }
+    }
+
+    /// Update the agent's last heartbeat.
+    pub fn heartbeat(&mut self) {
+        self.last_heartbeat = Local::now();
+    }
+
+    /// Update the agent's node metrics.
+    ///
+    /// # Arguments
+    ///
+    /// * `cpu` - The metrics related to the CPU.
+    /// * `memory` - The metrics related to memory.
+    pub fn update_node_metrics(&mut self, cpu: Option<NodeCpu>, memory: Option<NodeMemory>) {
+        self.heartbeat();
+        self.cpu = cpu;
+        self.memory = memory;
+    }
+}

--- a/scheduler/src/managers/node_agent/mod.rs
+++ b/scheduler/src/managers/node_agent/mod.rs
@@ -1,0 +1,5 @@
+//! Main modules for agent storage and management.
+
+pub mod errors;
+pub mod manager;
+pub mod metrics;


### PR DESCRIPTION
This adds the implementation for the different services referenced in the `agent.proto` to the `orka-scheduler` crate.

# Implementations
## Managers
The Scheduler now features a Node Agent Manager, responsible for the management and storage of the registered Agents. Custom errors have been implemented for better readability.

Each Node Agent contains the following members:
* a heartbeat, in order for the Scheduler to know which Agents are alive and responding;
* CPU metrics, which for now contain only the CPU load percentage;
* Memory metrics, which include total memory, and available memory, both in bytes.

## Node agent lifecycle
### Joining the cluster 
The Node Agent can connect to the Scheduler, then get registered against the Scheduler by giving its ID. If an Agent is already registered with this ID, the response status will be `ALREADY_EXISTS` (status code `6`).

The Scheduler is not responsible for Agent ID generation. However, we do advise:
* to generate the ID for each Agent process, rather than for each Node the Agent is installed onto;
* to generate an ID using an already-established format that will lead to a unique ID, such as UUIDv4.

**Note**: Agents are trusted by default because TLS is used for authenticating and securing the connection. If a user disables TLS, it is their responsibility to ensure that Agents can be trusted.

### Leaving the cluster
Upon a graceful exit, the Agent must send a disconnection notice to the Scheduler. This notice is always answered with an empty response and an OK status code, and the Agent can ignore this response.

## Node agent status updates
Right after its registration, the Agent must call the node status update endpoint. This will open a stream that the Agent must try to keep open for its entire lifetime.

Periodically, the Agent sends a status update, containing the metrics of the Node it is installed on. Those are listed in the [Managers section](#managers). This also allows the Scheduler to ensure the Agent is still alive and well.

Should the endpoint be called by an unregistered or unknown Agent, the stream will be closed with a response status of `NOT_FOUND` (status code `5`).

# What changes
The following changes have been made to the `agent.proto` file:
* the `ConnectionResponse` has been dropped in favour of `Empty`, using the gRPC status code to communicate the result instead
* a `DisconnectionNotice` has been added with an `id` field to identify which Agent is disconnecting
* an `id` field has been added to the `NodeStatus` arguments to identify which Agent is being updated