### PR TITLE
Refactoring of Node Agent's and Scheduler's protos

### DIFF
--- a/docs/proposals/node-agent/agent.proto
+++ b/docs/proposals/node-agent/agent.proto
@@ -2,51 +2,56 @@ syntax = "proto3";
 
 package node_agent;
 
-enum Signal {
-    STOP = 0;
-    KILL = 1;
-}
-
-enum Status {
-    WAITING = 0;
-    RUNNING = 1;
-    TERMINATED = 2;
-}
-
-enum Type {
-    CONTAINER = 0;
-}
-
-message Resource {
-    ResourceDetails limit = 1;
-    ResourceDetails usage = 2;
-}
-
-message ResourceDetails {
-    int32 cpu = 1;
-    int32 memory = 2;
-    int32 disk = 3;
-}
-
 message Workload {
-    string name = 1;
+    enum Type {
+        CONTAINER = 0;
+    }
+
+    message Resources {
+        optional int32 cpu = 1;
+        optional int32 memory = 2;
+        optional int32 disk = 3;
+    }
+
+    string instance_id = 1;
     Type type = 2;
     string image = 3;
     repeated string environment = 4;
-    Resource resource = 5;
+    optional Resources resource_limits = 5;
 }
 
 message WorkloadStatus {
-    string name = 1;
+    message Status {
+        enum StatusCode {
+            WAITING = 0;
+            RUNNING = 1;
+            TERMINATED = 2;
+        }
+
+        uint32 code = 1;
+        optional string message = 2;
+    }
+
+    message Resources {
+        int32 cpu = 1;
+        int32 memory = 2;
+        int32 disk = 3;
+    }
+
+    string instance_id = 1;
     Status status = 2;
-    Resource resource = 3;
-    string message = 4;
+    Resources resource_usage = 3;
 }
 
 message Empty {}
 
 message WorkloadSignal {
-    Workload workload = 1;
+    enum Signal {
+        STOP = 0;
+        KILL = 1;
+    }
+
+    string instance_id = 1;
     Signal signal = 2;
 }
 

--- a/docs/proposals/scheduler/controller.proto
+++ b/docs/proposals/scheduler/controller.proto
@@ -18,7 +18,7 @@ message Workload {
         optional int32 disk = 3;
     }
 
-    string name = 1;
+    string instance_id = 1;
     Type type = 2;
     string image = 3;
     repeated string environment = 4;
@@ -29,28 +29,16 @@ message SchedulingRequest {
     Workload workload = 1;
 }
 
-message SchedulingResponse {
-    enum StatusCode {
-        SCHEDULED = 0;
-        SCHEDULING = 1;
-        REJECTED = 2;
-    }
-
-    enum RejectionReason {
-        BAD_REQUEST = 0;
-        NO_CONTACTABLE_AGENT = 1;
-        AGENTS_REFUSED_OPERATION = 2;
-    }
-
-    StatusCode status_code = 1;
-    optional RejectionReason rejection_reason = 2;
-}
-
 message WorkloadStatus {
-    enum StatusCode {
-        WAITING = 0;
-        RUNNING = 1;
-        TERMINATED = 2;
+    message Status {
+        enum StatusCode {
+            WAITING = 0;
+            RUNNING = 1;
+            TERMINATED = 2;
+        }
+
+        uint32 code = 1;
+        optional string message = 2;
     }
 
     message Resources {
@@ -59,12 +47,19 @@ message WorkloadStatus {
         int32 disk = 3;
     }
 
-    string name = 1;
-    StatusCode status_code = 2;
+    string instance_id = 1;
+    Status status = 2;
     Resources resource_usage = 3;
-    string message = 4;
+}
+
+message Empty {}
+
+message WorkloadInstance {
+    string instance_id = 1;
 }
 
 service SchedulingService {
     rpc Schedule(SchedulingRequest) returns (stream WorkloadStatus);
+    rpc Stop (WorkloadInstance) returns (Empty);
+    rpc Destroy (WorkloadInstance) returns (Empty);
 }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,15 +1,13 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure()
-        .compile(
-            &["src/node-agent/agent.proto"],
-            &["src/node-agent"],
-        )?;
+    tonic_build::configure().compile(&["src/node-agent/agent.proto"], &["src/node-agent"])?;
 
-    tonic_build::configure()
-        .compile(
-            &["src/scheduler/agent.proto", "src/scheduler/controller.proto"],
-            &["src/scheduler"],
-        )?;
+    tonic_build::configure().compile(
+        &[
+            "src/scheduler/agent.proto",
+            "src/scheduler/controller.proto",
+        ],
+        &["src/scheduler"],
+    )?;
 
     Ok(())
 }

--- a/proto/src/node-agent/agent.proto
+++ b/proto/src/node-agent/agent.proto
@@ -2,51 +2,56 @@ syntax = "proto3";
 
 package node_agent;
 
-enum Signal {
-    STOP = 0;
-    KILL = 1;
-}
-
-enum Status {
-    WAITING = 0;
-    RUNNING = 1;
-    TERMINATED = 2;
-}
-
-enum Type {
-    CONTAINER = 0;
-}
-
-message Resource {
-    ResourceDetails limit = 1;
-    ResourceDetails usage = 2;
-}
-
-message ResourceDetails {
-    int32 cpu = 1;
-    int32 memory = 2;
-    int32 disk = 3;
-}
-
 message Workload {
-    string name = 1;
+    enum Type {
+        CONTAINER = 0;
+    }
+
+    message Resources {
+        optional int32 cpu = 1;
+        optional int32 memory = 2;
+        optional int32 disk = 3;
+    }
+
+    string instance_id = 1;
     Type type = 2;
     string image = 3;
     repeated string environment = 4;
-    Resource resource = 5;
+    optional Resources resource_limits = 5;
 }
 
 message WorkloadStatus {
-    string name = 1;
+    message Status {
+        enum StatusCode {
+            WAITING = 0;
+            RUNNING = 1;
+            TERMINATED = 2;
+        }
+
+        uint32 code = 1;
+        optional string message = 2;
+    }
+
+    message Resources {
+        int32 cpu = 1;
+        int32 memory = 2;
+        int32 disk = 3;
+    }
+
+    string instance_id = 1;
     Status status = 2;
-    Resource resource = 3;
-    string message = 4;
+    Resources resource_usage = 3;
 }
 
 message Empty {}
 
 message WorkloadSignal {
-    Workload workload = 1;
+    enum Signal {
+        STOP = 0;
+        KILL = 1;
+    }
+
+    string instance_id = 1;
     Signal signal = 2;
 }
 

--- a/proto/src/scheduler/controller.proto
+++ b/proto/src/scheduler/controller.proto
@@ -18,7 +18,7 @@ message Workload {
         optional int32 disk = 3;
     }
 
-    string name = 1;
+    string instance_id = 1;
     Type type = 2;
     string image = 3;
     repeated string environment = 4;
@@ -29,28 +29,16 @@ message SchedulingRequest {
     Workload workload = 1;
 }
 
-message SchedulingResponse {
-    enum StatusCode {
-        SCHEDULED = 0;
-        SCHEDULING = 1;
-        REJECTED = 2;
-    }
-
-    enum RejectionReason {
-        BAD_REQUEST = 0;
-        NO_CONTACTABLE_AGENT = 1;
-        AGENTS_REFUSED_OPERATION = 2;
-    }
-
-    StatusCode status_code = 1;
-    optional RejectionReason rejection_reason = 2;
-}
-
 message WorkloadStatus {
-    enum StatusCode {
-        WAITING = 0;
-        RUNNING = 1;
-        TERMINATED = 2;
+    message Status {
+        enum StatusCode {
+            WAITING = 0;
+            RUNNING = 1;
+            TERMINATED = 2;
+        }
+
+        uint32 code = 1;
+        optional string message = 2;
     }
 
     message Resources {
@@ -59,12 +47,19 @@ message WorkloadStatus {
         int32 disk = 3;
     }
 
-    string name = 1;
-    StatusCode status_code = 2;
+    string instance_id = 1;
+    Status status = 2;
     Resources resource_usage = 3;
-    string message = 4;
+}
+
+message Empty {}
+
+message WorkloadInstance {
+    string instance_id = 1;
 }
 
 service SchedulingService {
     rpc Schedule(SchedulingRequest) returns (stream WorkloadStatus);
+    rpc Stop (WorkloadInstance) returns (Empty);
+    rpc Destroy (WorkloadInstance) returns (Empty);
 }

--- a/scheduler/src/grpc/controller_scheduling_service.rs
+++ b/scheduler/src/grpc/controller_scheduling_service.rs
@@ -3,10 +3,11 @@
 use std::pin::Pin;
 
 use orka_proto::scheduler_controller::{
-    scheduling_service_server::SchedulingService, SchedulingRequest, WorkloadStatus,
+    scheduling_service_server::SchedulingService, Empty, SchedulingRequest, WorkloadInstance,
+    WorkloadStatus,
 };
 use tokio_stream::Stream;
-use tonic::{Request, Response, Result};
+use tonic::{Request, Response, Result, Status};
 
 /// Implementation of the `SchedulingService` gRPC service.
 pub struct ControllerSchedulingSvc {}
@@ -52,5 +53,21 @@ impl SchedulingService for ControllerSchedulingSvc {
         //Ok(Response::new(
         //    Box::pin(output_stream) as Self::ScheduleStream
         //))
+    }
+
+    /// Called by the controller to request a workload instance to be gracefully stopped.
+    async fn stop(
+        &self,
+        _: Request<WorkloadInstance>,
+    ) -> std::result::Result<Response<Empty>, Status> {
+        todo!()
+    }
+
+    /// Called by the controller to request a workload instance to be terminated.
+    async fn destroy(
+        &self,
+        _: Request<WorkloadInstance>,
+    ) -> std::result::Result<Response<Empty>, Status> {
+        todo!()
     }
 }


### PR DESCRIPTION
This adds the necessary changes in order for workload signals to propagate to the Node Agent.
Also disambiguates the term "name", as it was previously misunderstood.

# What changes
* Scheduler's `controller.proto` file:
    * renaming of underlying structures:
        * `StatusCode` becomes `Status` and gains a new optional message field
        * `WorkloadStatus`'s `status_code` field is renamed to `status`
    * addition of a new `Signal` function in the `SchedulingService` service
    * addition of a new `WorkloadSignal` argument for `Signal` function
* Node Agent's `agent.proto` file:
    * renaming of underlying structures:
        * `Workload`'s `resource` field has been renamed to `resource_limits` and is now optional
        * `WorkloadStatus`'s `resource` field has been renamed to `resource_usage`
    * `WorkloadSignal` argument has been modified to only require the workload's name
    * `Resource` limits and usages have been moved into the respective messages they belong to (`Workload`, `WorkloadStatus`)

# Implementation
Two new placeholder implementations for the `stop` and `destroy` methods of `SchedulingService`.
