### PR TITLE
Workload scheduling and signals

### DIFF
--- a/docs/proposals/scheduler/agent.proto
+++ b/docs/proposals/scheduler/agent.proto
@@ -11,6 +11,7 @@ message Empty {}
 
 message ConnectionRequest {
     string id = 1;
+    uint32 port = 2; // Expected to be in the uint16 boundaries
 }
 
 message DisconnectionNotice {

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -9,3 +9,5 @@ pub mod scheduler_agent {
 pub mod scheduler_controller {
     tonic::include_proto!("scheduler.controller");
 }
+
+pub mod scheduler;

--- a/proto/src/scheduler/agent.proto
+++ b/proto/src/scheduler/agent.proto
@@ -11,6 +11,7 @@ message Empty {}
 
 message ConnectionRequest {
     string id = 1;
+    uint32 port = 2; // Expected to be in the uint16 boundaries
 }
 
 message DisconnectionNotice {

--- a/proto/src/scheduler/mappers.rs
+++ b/proto/src/scheduler/mappers.rs
@@ -1,0 +1,40 @@
+use crate::{node_agent, scheduler_controller};
+
+impl From<scheduler_controller::Workload> for node_agent::Workload {
+    fn from(value: scheduler_controller::Workload) -> Self {
+        Self {
+            instance_id: value.instance_id,
+            image: value.image,
+            environment: value.environment,
+            r#type: value.r#type,
+            resource_limits: value
+                .resource_limits
+                .map(|r| node_agent::workload::Resources {
+                    memory: r.memory,
+                    cpu: r.cpu,
+                    disk: r.disk,
+                }),
+        }
+    }
+}
+
+impl From<node_agent::WorkloadStatus> for scheduler_controller::WorkloadStatus {
+    fn from(value: node_agent::WorkloadStatus) -> Self {
+        Self {
+            instance_id: value.instance_id,
+            status: value
+                .status
+                .map(|s| scheduler_controller::workload_status::Status {
+                    code: s.code,
+                    message: s.message,
+                }),
+            resource_usage: value.resource_usage.map(|r| {
+                scheduler_controller::workload_status::Resources {
+                    cpu: r.cpu,
+                    memory: r.memory,
+                    disk: r.disk,
+                }
+            }),
+        }
+    }
+}

--- a/proto/src/scheduler/mod.rs
+++ b/proto/src/scheduler/mod.rs
@@ -1,0 +1,1 @@
+pub mod mappers;

--- a/scheduler/src/grpc/agent_lifecycle_service.rs
+++ b/scheduler/src/grpc/agent_lifecycle_service.rs
@@ -1,9 +1,11 @@
 //! Lifecycle gRPC service for the Orka node agents.
 
+use crate::managers::node_agent::errors::NodeAgentError;
 use crate::managers::node_agent::manager::NodeAgentManager;
 use orka_proto::scheduler_agent::{
     lifecycle_service_server::LifecycleService, ConnectionRequest, DisconnectionNotice, Empty,
 };
+use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use tonic::{Request, Response, Result, Status};
 use tracing::{event, Level};
@@ -34,8 +36,33 @@ impl LifecycleService for AgentLifecycleSvc {
         &self,
         request: Request<ConnectionRequest>,
     ) -> Result<Response<Empty>, Status> {
-        let agent_id = request.into_inner().id;
+        let remote_addr = request.remote_addr();
+        let inner = request.into_inner();
+        let agent_id = inner.id;
 
+        // Gather remote port and address for agent
+        let agent_port = u16::try_from(inner.port).map_err(|_| {
+            event!(
+                Level::ERROR,
+                agent_id,
+                provided_port = inner.port,
+                "Agent provided port outside valid range"
+            );
+
+            Status::from(NodeAgentError::NoRemoteAddress())
+        })?;
+
+        let remote_addr = remote_addr.ok_or_else(|| {
+            event!(
+                Level::ERROR,
+                agent_id,
+                "Could not retrieve remote address during agent registration. Agent would be unreachable, refusing registration"
+            );
+
+            Status::from(NodeAgentError::NoRemoteAddress())
+        })?;
+
+        // Prepare manager
         let mut manager = self.node_agent_manager.lock().map_err(|err| {
             event!(
                 Level::WARN,
@@ -47,7 +74,10 @@ impl LifecycleService for AgentLifecycleSvc {
             Status::internal("Failed to register agent")
         })?;
 
-        match manager.add_agent(&agent_id) {
+        // Add agent
+        let agent_addr = SocketAddr::new(remote_addr.ip(), agent_port);
+
+        match manager.add_agent(agent_id.clone(), agent_addr) {
             Ok(_) => Ok(Response::new(Empty {})),
             Err(err) => {
                 event!(

--- a/scheduler/src/grpc/agent_lifecycle_service.rs
+++ b/scheduler/src/grpc/agent_lifecycle_service.rs
@@ -65,7 +65,7 @@ impl LifecycleService for AgentLifecycleSvc {
         // Prepare manager
         let mut manager = self.node_agent_manager.lock().map_err(|err| {
             event!(
-                Level::WARN,
+                Level::ERROR,
                 agent_id,
                 error = %err,
                 "Failed to acquire node manager, refusing registration for agent"
@@ -105,7 +105,7 @@ impl LifecycleService for AgentLifecycleSvc {
             }
             Err(err) => {
                 event!(
-                    Level::WARN,
+                    Level::ERROR,
                     agent_id,
                     error = %err,
                     "Failed to acquire node manager, could not remove agent"

--- a/scheduler/src/grpc/agent_status_update_service.rs
+++ b/scheduler/src/grpc/agent_status_update_service.rs
@@ -56,7 +56,7 @@ impl StatusUpdateService for AgentStatusUpdateSvc {
 
                         if let Err(err) = res {
                             event!(
-                                Level::WARN,
+                                Level::ERROR,
                                 agent_id = status.id,
                                 error = %err,
                                 "Unable to process node status update"
@@ -67,7 +67,7 @@ impl StatusUpdateService for AgentStatusUpdateSvc {
                     }
                     Err(err) => {
                         event!(
-                            Level::WARN,
+                            Level::ERROR,
                             agent_id = status.id,
                             error = %err,
                             "Failed to acquire node manager, cannot process node status update for agent"
@@ -78,7 +78,7 @@ impl StatusUpdateService for AgentStatusUpdateSvc {
                 },
                 Err(err) => {
                     event!(
-                        Level::WARN,
+                        Level::ERROR,
                         error = %err,
                         "An error was received while processing a node status update stream"
                     );

--- a/scheduler/src/grpc/controller_scheduling_service.rs
+++ b/scheduler/src/grpc/controller_scheduling_service.rs
@@ -1,73 +1,355 @@
 //! Scheduling gRPC service for the Orka controller.
 
+use crate::managers::node_agent::manager::NodeAgentManager;
+use crate::managers::workload::errors::WorkloadError;
+use crate::managers::workload::manager::WorkloadManager;
+use anyhow::Result;
+use orka_proto::node_agent::workload_service_client::WorkloadServiceClient;
+use orka_proto::node_agent::workload_signal::Signal;
+use orka_proto::node_agent::{Workload, WorkloadSignal, WorkloadStatus as AgentWorkloadStatus};
+use orka_proto::scheduler_controller::scheduling_service_server::SchedulingService;
+use orka_proto::scheduler_controller::WorkloadStatus as ControllerWorkloadStatus;
+use orka_proto::scheduler_controller::{Empty, SchedulingRequest, WorkloadInstance};
 use std::pin::Pin;
-
-use orka_proto::scheduler_controller::{
-    scheduling_service_server::SchedulingService, Empty, SchedulingRequest, WorkloadInstance,
-    WorkloadStatus,
-};
-use tokio_stream::Stream;
-use tonic::{Request, Response, Result, Status};
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::{Stream, StreamExt};
+use tonic::Response;
+use tonic::{Request, Status, Streaming};
+use tracing::{event, Level};
 
 /// Implementation of the `SchedulingService` gRPC service.
-pub struct ControllerSchedulingSvc {}
+pub struct ControllerSchedulingSvc {
+    /// The shared instance of the node agent manager.
+    node_agent_manager: Arc<Mutex<NodeAgentManager>>,
+    /// The shared instance of the workload manager.
+    workload_manager: Arc<Mutex<WorkloadManager>>,
+}
 
 impl ControllerSchedulingSvc {
     /// Create a new `SchedulingService` gRPC service manager.
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(
+        node_agent_manager: Arc<Mutex<NodeAgentManager>>,
+        workload_manager: Arc<Mutex<WorkloadManager>>,
+    ) -> Self {
+        Self {
+            node_agent_manager,
+            workload_manager,
+        }
     }
 }
 
 #[tonic::async_trait]
 impl SchedulingService for ControllerSchedulingSvc {
-    type ScheduleStream = Pin<Box<dyn Stream<Item = Result<WorkloadStatus>> + Send>>;
+    type ScheduleStream =
+        Pin<Box<dyn Stream<Item = Result<ControllerWorkloadStatus, Status>> + Send>>;
 
     /// Called by the controller when it requests to schedule a workload on a node. The scheduler
     /// responds by streaming status information about the workload.
     async fn schedule(
         &self,
-        _: Request<SchedulingRequest>,
-    ) -> Result<Response<Self::ScheduleStream>> {
-        todo!();
-        // Example: https://github.com/hyperium/tonic/blob/master/examples/src/streaming
-        //let (tx, rx) = mpsc::channel(128);
-        //tokio::spawn(async move {
-        //    match tx.send(Ok(WorkloadStatus {
-        //        name: "my_workload".to_string(),
-        //        status_code: StatusCode::Running.into(),
-        //        resource_usage: Some(Resources {
-        //            cpu: 1,
-        //            memory: 1,
-        //            disk: 1,
-        //        }),
-        //        message: "Everything is fine".to_string(),
-        //    }))
-        //    .await {
-        //        Ok(_) => (),
-        //        Err(_) => (),
-        //    };
-        //});
+        request: Request<SchedulingRequest>,
+    ) -> Result<Response<Self::ScheduleStream>, Status> {
+        // Get workload ready to send
+        let scheduling_request = request.into_inner();
+        let scheduling_workload = scheduling_request.workload.ok_or_else(|| {
+            event!(
+                Level::ERROR,
+                "Schedule request received, but the workload was missing"
+            );
 
-        //let output_stream = ReceiverStream::new(rx);
-        //Ok(Response::new(
-        //    Box::pin(output_stream) as Self::ScheduleStream
-        //))
+            WorkloadError::InvalidWorkload("".to_string())
+        })?;
+
+        let workload = Workload::from(scheduling_workload);
+
+        let (tx, rx) = mpsc::channel(8);
+        let manager = self.node_agent_manager.lock().map_err(|err| {
+            event!(
+                Level::ERROR,
+                workload_instance_id = workload.instance_id,
+                error = %err,
+                "Failed to acquire node manager, unable to proceed with workload scheduling"
+            );
+
+            Status::internal("Failed to retrieve node agent manager")
+        })?;
+
+        // Choose a fitting node agent
+        // TODO: Do a clean architecture for code choosing a target
+        let agent = manager.agents_iter().next().ok_or_else(|| {
+            event!(
+                Level::ERROR,
+                workload_instance_id = workload.instance_id,
+                "No node is registered to schedule a workload on"
+            );
+
+            Status::failed_precondition("No nodes in the cluster")
+        })?;
+
+        let workload_manager = Arc::clone(&self.workload_manager);
+        let agent_id = agent.id().to_string();
+        let agent_address = agent.grpc_url();
+
+        tokio::spawn(async move {
+            // Request the agent to create the workload
+            let workload_instance_id = workload.instance_id.clone();
+
+            let mut workload_status_stream = match Self::create_workload_on_agent(
+                workload,
+                agent_address,
+            )
+            .await
+            {
+                Ok(v) => v,
+                Err(err) => {
+                    event!(
+                        Level::ERROR,
+                        workload_instance_id,
+                        error = %err,
+                        "Failed to acquire node manager, unable to proceed with workload scheduling"
+                    );
+
+                    let _ = tx.send(Err(err)).await;
+                    return;
+                }
+            };
+
+            // Register workload and link to its supporting agent
+            let res = match workload_manager.lock() {
+                Ok(mut v) => {
+                    v.add_instance(workload_instance_id.clone(), agent_id);
+                    Ok(())
+                }
+                Err(err) => {
+                    event!(
+                        Level::ERROR,
+                        workload_instance_id,
+                        error = %err,
+                        "Failed to acquire node manager, unable to register the workload instance locally"
+                    );
+
+                    Err(Status::internal(
+                        "Could not register the instance in the scheduler",
+                    ))
+                }
+            };
+
+            if let Err(err) = res {
+                let _ = tx.send(Err(err)).await;
+                return;
+            }
+
+            while let Some(result) = workload_status_stream.next().await {
+                // Ensure no errors in the stream
+                let agent_workload_status = match result {
+                    Ok(v) => v,
+                    Err(err) => {
+                        event!(
+                            Level::ERROR,
+                            workload_instance_id,
+                            error = %err,
+                            "An error occurred while processing a workload status stream"
+                        );
+
+                        let _ = tx
+                            .send(Err(Status::internal(
+                                "Could not retrieve workload status from agent",
+                            )))
+                            .await;
+
+                        break;
+                    }
+                };
+
+                // Translate the received workload status before sending it back
+                let controller_workload_status =
+                    ControllerWorkloadStatus::from(agent_workload_status);
+
+                let res = tx.send(Ok(controller_workload_status)).await;
+
+                if let Err(err) = res {
+                    event!(
+                        Level::ERROR,
+                        workload_instance_id,
+                        error = %err,
+                        "An error occurred while sending a workload status"
+                    );
+
+                    break;
+                }
+            }
+        });
+
+        let output_stream = ReceiverStream::new(rx);
+        Ok(Response::new(
+            Box::pin(output_stream) as Self::ScheduleStream
+        ))
     }
 
     /// Called by the controller to request a workload instance to be gracefully stopped.
-    async fn stop(
-        &self,
-        _: Request<WorkloadInstance>,
-    ) -> std::result::Result<Response<Empty>, Status> {
-        todo!()
+    async fn stop(&self, request: Request<WorkloadInstance>) -> Result<Response<Empty>, Status> {
+        self.handle_signal_request(request, Signal::Stop).await
     }
 
     /// Called by the controller to request a workload instance to be terminated.
-    async fn destroy(
+    async fn destroy(&self, request: Request<WorkloadInstance>) -> Result<Response<Empty>, Status> {
+        self.handle_signal_request(request, Signal::Kill).await
+    }
+}
+
+impl ControllerSchedulingSvc {
+    /// Handle the request of sending a signal to a workload instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The request that was received.
+    /// * `signal` - The signal to send to the workload instance.
+    ///
+    /// # Errors
+    ///
+    /// * The node agent address associated with the workload instance could not be found.
+    /// * The workload signal request failed.
+    async fn handle_signal_request(
         &self,
-        _: Request<WorkloadInstance>,
-    ) -> std::result::Result<Response<Empty>, Status> {
-        todo!()
+        request: Request<WorkloadInstance>,
+        signal: Signal,
+    ) -> Result<Response<Empty>, Status> {
+        // Find the agent address associated with this workload instance
+        let inner_request = request.into_inner();
+
+        let agent_address = match self
+            .find_agent_address_from_instance(inner_request.instance_id.clone())
+        {
+            Ok(v) => v,
+            Err(err) => {
+                event!(
+                    Level::ERROR,
+                    workload_instance_id = inner_request.instance_id,
+                    ?signal,
+                    error = %err,
+                    "Unable to get the agent address of the workload instance, a signal could not be delivered"
+                );
+
+                return Err(err);
+            }
+        };
+
+        // Send the signal request to the node agent
+        let res =
+            Self::send_workload_signal(inner_request.instance_id.clone(), signal, agent_address)
+                .await;
+
+        if let Err(err) = res {
+            event!(
+                Level::ERROR,
+                workload_instance_id = inner_request.instance_id,
+                ?signal,
+                error = %err,
+                "An error occurred while sending a signal request to a node agent"
+            );
+
+            return Err(err);
+        }
+
+        Ok(Response::new(Empty {}))
+    }
+
+    /// Find the address of the node agent that's running a workload instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `instance_id` - The ID of the workload instance to find the associated node agent with.
+    ///
+    /// # Errors
+    ///
+    /// * The workload manager mutex cannot be locked.
+    /// * The workload is unknown.
+    /// * The node agent manager mutex cannot be locked.
+    /// * The agent associated with the workload is unknown.
+    fn find_agent_address_from_instance(&self, instance_id: String) -> Result<String, Status> {
+        let workload_manager = self
+            .workload_manager
+            .lock()
+            .map_err(|_| Status::internal("Failed to retrieve workload manager"))?;
+
+        let agent_id = workload_manager
+            .find_related_agent(&instance_id)
+            .ok_or(Status::invalid_argument("Unknown workload"))?;
+
+        let node_agent_manager = self
+            .node_agent_manager
+            .lock()
+            .map_err(|_| Status::internal("Failed to retrieve node agent manager"))?;
+
+        let agent = node_agent_manager
+            .get_agent(agent_id)
+            .ok_or(Status::internal("No agent corresponding to workload"))?;
+
+        Ok(agent.grpc_url())
+    }
+
+    /// Send a workload creation request to a node agent, and return a
+    /// stream containing status updates about the instance of this workload.
+    ///
+    /// # Arguments
+    ///
+    /// * `workload` - The workload to create on the agent.
+    /// * `address` - The address to connect to the agent.
+    ///
+    /// # Errors
+    ///
+    /// * Unable to connect to the agent.
+    /// * The agent couldn't fulfill the request.
+    async fn create_workload_on_agent(
+        workload: Workload,
+        address: String,
+    ) -> Result<Streaming<AgentWorkloadStatus>, Status> {
+        let mut client = WorkloadServiceClient::connect(address)
+            .await
+            .map_err(|_| Status::internal("Failed to contact designated node agent"))?;
+
+        let request = Request::new(workload);
+        match client.create(request).await {
+            Ok(stream) => Ok(stream.into_inner()),
+            Err(err) => Err(Status::internal(format!(
+                "Failed to retrieve node agent workload status. Agent sent: {} (code {})",
+                err.message(),
+                err.code()
+            ))),
+        }
+    }
+
+    /// Send a request to a node agent to send a signal to a workload instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `instance_id` - The ID of the workload instance to send a signal to.
+    /// * `signal` - The signal to send to the workload instance.
+    /// * `address` - The address to connect to the agent.
+    ///
+    /// # Errors
+    ///
+    /// * Unable to connect to the agent.
+    /// * The agent couldn't fulfill the request.
+    async fn send_workload_signal(
+        instance_id: String,
+        signal: Signal,
+        address: String,
+    ) -> Result<(), Status> {
+        let mut client = WorkloadServiceClient::connect(address)
+            .await
+            .map_err(|_| Status::internal("Failed to contact designated node agent"))?;
+
+        let request = Request::new(WorkloadSignal {
+            instance_id,
+            signal: signal.into(),
+        });
+
+        match client.signal(request).await {
+            Ok(_) => Ok(()),
+            Err(_) => Err(Status::internal("Failed to send signal to node agent")),
+        }
     }
 }

--- a/scheduler/src/grpc/errors.rs
+++ b/scheduler/src/grpc/errors.rs
@@ -3,12 +3,23 @@
 use tonic::Status;
 
 use crate::managers::node_agent::errors::NodeAgentError;
+use crate::managers::workload::errors::WorkloadError;
 
 impl From<NodeAgentError> for Status {
     fn from(value: NodeAgentError) -> Self {
         match value {
             NodeAgentError::NotFound(_) => Self::not_found(value.to_string()),
             NodeAgentError::AlreadyExists(_) => Self::already_exists(value.to_string()),
+            NodeAgentError::NoRemoteAddress() => Self::internal(value.to_string()),
+            NodeAgentError::InvalidPort() => Status::invalid_argument(value.to_string()),
+        }
+    }
+}
+
+impl From<WorkloadError> for Status {
+    fn from(value: WorkloadError) -> Self {
+        match value {
+            WorkloadError::InvalidWorkload(_) => Status::invalid_argument(value.to_string()),
         }
     }
 }

--- a/scheduler/src/grpc/server.rs
+++ b/scheduler/src/grpc/server.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
 use crate::managers::node_agent::manager::NodeAgentManager;
+use crate::managers::workload::manager::WorkloadManager;
 use anyhow::{Context, Result};
 use orka_proto::{
     scheduler_agent::{
@@ -89,6 +90,7 @@ impl GrpcServer {
 
         // Create the shared node agent manager
         let node_agent_manager = Arc::new(Mutex::new(NodeAgentManager::new()));
+        let workload_manager = Arc::new(Mutex::new(WorkloadManager::new()));
 
         // Configure the router
         let router = server_builder
@@ -98,7 +100,10 @@ impl GrpcServer {
             .add_service(StatusUpdateServiceServer::new(AgentStatusUpdateSvc::new(
                 Arc::clone(&node_agent_manager),
             )))
-            .add_service(SchedulingServiceServer::new(ControllerSchedulingSvc::new()));
+            .add_service(SchedulingServiceServer::new(ControllerSchedulingSvc::new(
+                Arc::clone(&node_agent_manager),
+                Arc::clone(&workload_manager),
+            )));
 
         event!(Level::DEBUG, "The gRPC server was configured successfully");
 

--- a/scheduler/src/managers/mod.rs
+++ b/scheduler/src/managers/mod.rs
@@ -1,3 +1,5 @@
 //! Managers for the scheduler subsystems.
 
 pub mod node_agent;
+
+pub mod workload;

--- a/scheduler/src/managers/node_agent/errors.rs
+++ b/scheduler/src/managers/node_agent/errors.rs
@@ -12,4 +12,10 @@ pub enum NodeAgentError {
     /// The node agent is already registered.
     #[error("Agent already exists: `{0}`")]
     AlreadyExists(String),
+
+    #[error("Agent has no remote address")]
+    NoRemoteAddress(),
+
+    #[error("Agent provided port outside boundaries")]
+    InvalidPort(),
 }

--- a/scheduler/src/managers/node_agent/metrics.rs
+++ b/scheduler/src/managers/node_agent/metrics.rs
@@ -1,6 +1,7 @@
 //! Node agent and its metrics.
 
 use chrono::{DateTime, Local};
+use std::net::SocketAddr;
 
 /// The memory (RAM) information of the node the agent is installed on.
 #[derive(Debug, Clone)]
@@ -22,6 +23,10 @@ pub struct NodeCpu {
 /// The node agent and the information it broadcasts.
 #[derive(Debug, Clone)]
 pub struct NodeAgent {
+    /// The agent's unique id.
+    id: String,
+    /// Address the agent is reachable at.
+    address: SocketAddr,
     /// Heartbeat represents the last time the agent communicated with the scheduler.
     /// This is used to determine whether the agent has timed out.
     last_heartbeat: DateTime<Local>,
@@ -35,12 +40,30 @@ pub struct NodeAgent {
 
 impl NodeAgent {
     /// Create a new `NodeAgent`.
-    pub fn new() -> Self {
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the node agent.
+    /// * `address` - The address where the node agent is reachable at.
+    pub fn new(id: String, address: SocketAddr) -> Self {
         NodeAgent {
+            id,
+            address,
             last_heartbeat: Local::now(),
             memory: None,
             cpu: None,
         }
+    }
+
+    /// Get the agent's id.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Get the agent's formatted server address.
+    /// This is the URL that should be used to contact its gRPC server.
+    pub fn grpc_url(&self) -> String {
+        format!("http://{}", self.address)
     }
 
     /// Update the agent's last heartbeat.

--- a/scheduler/src/managers/workload/errors.rs
+++ b/scheduler/src/managers/workload/errors.rs
@@ -1,0 +1,11 @@
+//! Workload errors.
+
+use thiserror::Error;
+
+/// Agent error enum to have self-explanatory and compact errors.
+#[derive(Error, Debug)]
+pub enum WorkloadError {
+    /// The controller doesn't provide a valid Workload .
+    #[error("Invalid workload: `{0}`")]
+    InvalidWorkload(String),
+}

--- a/scheduler/src/managers/workload/manager.rs
+++ b/scheduler/src/managers/workload/manager.rs
@@ -1,0 +1,48 @@
+//! Workload manager used to store workload instances.
+
+use std::collections::HashMap;
+
+use tracing::{event, Level};
+
+/// The workload manager, handling all workload instances that were created on the nodes of the
+/// cluster.
+pub struct WorkloadManager {
+    /// The managed instances.
+    /// Stored under the form `instance_id -> agent_id`.
+    instances: HashMap<String, String>,
+}
+
+impl WorkloadManager {
+    /// Create a new workload manager.
+    pub fn new() -> Self {
+        WorkloadManager {
+            instances: HashMap::new(),
+        }
+    }
+
+    /// Add a new instance to the list.
+    ///
+    /// # Arguments
+    ///
+    /// * `instance_id` - The ID of the workload instance to add.
+    /// * `agent_id` - The ID of the node agent where this workload instance is running.
+    pub fn add_instance(&mut self, instance_id: String, agent_id: String) {
+        event!(
+            Level::TRACE,
+            workload_instance_id = instance_id,
+            agent_id,
+            "Registering new workload instance"
+        );
+
+        self.instances.insert(instance_id, agent_id);
+    }
+
+    /// Find the node agent associated with a workload instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `instance_id` - The ID of the workload instance to find the associated node agent with.
+    pub fn find_related_agent(&self, instance_id: &str) -> Option<&String> {
+        self.instances.get(&instance_id.to_string())
+    }
+}

--- a/scheduler/src/managers/workload/mod.rs
+++ b/scheduler/src/managers/workload/mod.rs
@@ -1,0 +1,4 @@
+//! Main modules for scheduler type mapping.
+
+pub mod errors;
+pub mod manager;


### PR DESCRIPTION
This adds the scheduling logic for the Orka's Scheduler.

# Implementation
## Scheduling requests
The Scheduler can handle incoming scheduling requests from the Controller. The Scheduler then decides of the fitting Agent, and contacts to assign it the workload. Two one-way streams are then established: one from the Node Agent to the Scheduler, and the other from the Scheduler to the Controller. Every workload status update sent by the Agent is then re-mapped and forwarded to the Controller.

The stream to the Controller is closed after the Agent's stream was closed. As the Scheduler never closes said streams itself, an unexpected end of the Scheduler-Controller stream must cause an error or a warning in the Controller. It is the Controller's responsibility to re-open the streams, or - upon re-gaining contact with the Scheduler - to send the appropriate signal to terminate the Workload.

## Workload signals
The Scheduler implements two methods, `stop` and `destroy`, that allow the Controller to request the respective signals to be sent to the workload. Said signal is thus forwarded by the Scheduler to the corresponding Node Agent, according to the association `instance -> agent` that the Scheduler possesses. An error is thrown if the instance ID is unknown, unbound (no corresponding Agent that hosts the workload) or if the Agent sends an error. In case of an error, the Controller must assume the signal has not gone through and the workload is still running.

# What changes
* Scheduler's `agent.proto`:
    * add `port` to the `ConnectionRequest` message. This is the Agent's gRPC server port that will be used by the Scheduler.
* Scheduler source code:
    * update severity of a few logging events from `WARN` to `ERROR`.